### PR TITLE
classes/bootspec: ensure STAGING_KERNEL_BUILDDIR is populated

### DIFF
--- a/classes/bootspec.bbclass
+++ b/classes/bootspec.bbclass
@@ -1,6 +1,8 @@
 # Adds boot spec entry for first FSTYPE found
-inherit linux-kernel-base
 
+# require STAGING_KERNEL_BUILDDIR to be populated properly
+do_rootfs[depends] += "virtual/kernel:do_shared_workdir"
+inherit linux-kernel-base
 KERNEL_VERSION = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"
 
 BOOTSPEC_TITLE ?= "${SUMMARY}"


### PR DESCRIPTION
The STAGING_KERNEL_BUILDDIR must be populated in order to run
get_kernelversion_file() properly on it.

To achieve this, we add a dependency on kernels do_shared_workdir task
before building the rootfs.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>