### PR TITLE
classes/bootspec: use regular file instead of symlink for 'devicetree' entry

### DIFF
--- a/classes/bootspec.bbclass
+++ b/classes/bootspec.bbclass
@@ -52,7 +52,7 @@ python create_bootspec() {
         bootspecfile.write('options    %s\n' % d.expand('${BOOTSPEC_OPTIONS}'))
         bootspecfile.write(d.getVar('BOOTSPEC_EXTRALINE', True).replace(r'\n', '\n'))
         bootspecfile.write('linux      %s\n' % d.expand('/boot/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}'))
-        bootspecfile.write('devicetree %s\n' % d.expand('/boot/devicetree-${KERNEL_IMAGETYPE}-' + x + '.dtb\n'))
+        bootspecfile.write('devicetree %s\n' % d.expand('/boot/' + x + '.dtb\n'))
 
         bootspecfile.close()
 }


### PR DESCRIPTION
Please consider cherry-picking this commit for the rocko branch as well.