### PR TITLE
conf: layer: set LAYERSERIES_COMPAT for this layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "ptx"
 BBFILE_PATTERN_ptx = "^${LAYERDIR}/"
 BBFILE_PRIORITY_ptx = "6"
+
+LAYERSERIES_COMPAT_ptx = "sumo rocko"


### PR DESCRIPTION
Setting this variable is used since sumo to track layer compatibility
and active layer maintanance.
Setting this will prevent from utriggering a warning and is required for
Yocto Project Compatible version 2 standard.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>