### PR TITLE
dt-utils: fix compilation with newer glibc version

### DIFF
--- a/recipes-core/dt-utils/dt-utils/src-fix-compilation-for-glibc-version-2.27.9000-36.f.patch
+++ b/recipes-core/dt-utils/dt-utils/src-fix-compilation-for-glibc-version-2.27.9000-36.f.patch
@@ -1,0 +1,73 @@
+From 1c80e31872aec9f2ef7eca6a52aa89c0ea759d8f Mon Sep 17 00:00:00 2001
+From: Enrico Joerns <ejo@pengutronix.de>
+Date: Wed, 5 Sep 2018 12:28:28 +0200
+Subject: [PATCH] src: fix compilation for glibc version 2.27.9000-36.fc29 and
+ newer
+
+As recent glibc versions (>= 2.27.9000-36.fc29) also define 'struct
+statx' which is also defined in linux/stat.h, compilation fails with
+error:
+
+| In file included from ../dt-utils-2018.05.0/src/crypto/digest.c:24:
+| [..]/usr/include/linux/stat.h:56:8: error: redefinition of 'struct statx_timestamp'
+|  struct statx_timestamp {
+|         ^~~~~~~~~~~~~~~
+| In file included from [..]/usr/include/sys/stat.h:446,
+|                  from ../dt-utils-2018.05.0/src/dt/common.h:15,
+|                  from ../dt-utils-2018.05.0/src/crypto/digest.c:19:
+| [..]/usr/include/bits/statx.h:25:8: note: originally defined here
+|  struct statx_timestamp
+|         ^~~~~~~~~~~~~~~
+| In file included from ../dt-utils-2018.05.0/src/crypto/digest.c:24:
+| [..]/usr/include/linux/stat.h:99:8: error: redefinition of 'struct statx'
+|  struct statx {
+|         ^~~~~
+| In file included from [..]/usr/include/sys/stat.h:446,
+|                  from ../dt-utils-2018.05.0/src/dt/common.h:15,
+|                  from ../dt-utils-2018.05.0/src/crypto/digest.c:19:
+| [..]/usr/include/bits/statx.h:36:8: note: originally defined here
+|  struct statx
+|         ^~~~~
+
+The linux/stat.h originates from the code that was copied from barebox
+but is not explicitly required to be linux/stat.h instead of sys/stat.h
+and we do not actually use struct statx.
+
+Thus it is safe to simply replace occurrences of linux/stat.h by
+sys/stat.h to fix compilation.
+
+Signed-off-by: Enrico Joerns <ejo@pengutronix.de>
+---
+ src/barebox-state/backend_storage.c | 2 +-
+ src/crypto/digest.c                 | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/barebox-state/backend_storage.c b/src/barebox-state/backend_storage.c
+index 53fe829..1052656 100644
+--- a/src/barebox-state/backend_storage.c
++++ b/src/barebox-state/backend_storage.c
+@@ -19,7 +19,7 @@
+ #include <linux/kernel.h>
+ #include <linux/list.h>
+ #include <linux/mtd/mtd-abi.h>
+-#include <linux/stat.h>
++#include <sys/stat.h>
+ #include <linux/fs.h>
+ #include <malloc.h>
+ #include <printk.h>
+diff --git a/src/crypto/digest.c b/src/crypto/digest.c
+index 7a8c3c0..8353412 100644
+--- a/src/crypto/digest.c
++++ b/src/crypto/digest.c
+@@ -21,7 +21,7 @@
+ #include <malloc.h>
+ #include <fs.h>
+ #include <fcntl.h>
+-#include <linux/stat.h>
++#include <sys/stat.h>
+ #include <errno.h>
+ #include <module.h>
+ #include <linux/err.h>
+-- 
+2.11.0
+

--- a/recipes-core/dt-utils/dt-utils_2018.05.0.bb
+++ b/recipes-core/dt-utils/dt-utils_2018.05.0.bb
@@ -2,3 +2,5 @@ require dt-utils.inc
 
 SRC_URI[md5sum] = "3ab2d646639bb10607716a5b57e2ddf8"
 SRC_URI[sha256sum] = "fbb3393a76a63a0769135719ae3865e885efbbf4a44ba1d5ec7ebbadbcb3327a"
+
+SRC_URI += "file://src-fix-compilation-for-glibc-version-2.27.9000-36.f.patch"


### PR DESCRIPTION
Jenkins test build failed on master because of being incompatible with recent glibc version.

Add this patch from upstream dt-utils to fix this.