### PR TITLE
[sumo] update ptx.conf to sumo release

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -1,7 +1,7 @@
 DISTRO = "ptx"
-DISTRO_NAME = "PTX - Poky (Yocto Project Reference Distro"
-DISTRO_VERSION = "2.4"
-DISTRO_CODENAME = "ptx-rocko"
+DISTRO_NAME = "PTX - Poky (Yocto Project Reference Distro)"
+DISTRO_VERSION = "2.5-0"
+DISTRO_CODENAME = "ptx-sumo"
 
 DISTROOVERRIDES =. "ptx:poky:"
 
@@ -57,3 +57,5 @@ ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
 
 require conf/distro/include/poky-world-exclude.inc
 require conf/distro/include/no-static-libs.inc
+require conf/distro/include/yocto-uninative.inc
+INHERIT += "uninative"

--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -1,9 +1,7 @@
-require conf/distro/poky.conf
-
 DISTRO = "ptx"
-DISTRO_NAME_prepend = "PTX - "
-DISTRO_VERSION = "1.8-0"
-DISTRO_CODENAME = "ptx-fido"
+DISTRO_NAME = "PTX - Poky (Yocto Project Reference Distro"
+DISTRO_VERSION = "2.4"
+DISTRO_CODENAME = "ptx-rocko"
 
 DISTROOVERRIDES =. "ptx:poky:"
 
@@ -13,9 +11,11 @@ TARGET_VENDOR = "-ptx"
 
 LOCALCONF_VERSION = "1"
 
+DISTRO_VERSION[vardepsexclude] = "DATE"
+SDK_VERSION[vardepsexclude] = "DATE"
 # Override these in ptx based distros
-PTX_DEFAULT_DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost xattr nfs zeroconf multiarch systemd"
-PTX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot init-ifupdown"
+PTX_DEFAULT_DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost wifi xattr nfs zeroconf multiarch systemd"
+PTX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 PTX_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 
 DISTRO_FEATURES = "${DISTRO_FEATURES_LIBC} ${PTX_DEFAULT_DISTRO_FEATURES}"
@@ -27,6 +27,8 @@ VIRTUAL-RUNTIME_initscripts = ""
 DISTRO_EXTRA_RDEPENDS += " ${PTX_DEFAULT_EXTRA_RDEPENDS}"
 DISTRO_EXTRA_RRECOMMENDS += " ${PTX_DEFAULT_EXTRA_RRECOMMENDS}"
 
+TCLIBCAPPEND = ""
+
 # add build
 INHERIT += "image-buildinfo"
 
@@ -34,3 +36,24 @@ INHERIT += "image-buildinfo"
 # to enable icecc in your build, add ICECC_DISABLED = "" to your local.conf
 INHERIT_DISTRO_append = " icecc"
 ICECC_DISABLED ??= "1"
+
+#
+# OELAYOUT_ABI allows us to notify users when the format of TMPDIR changes in
+# an incompatible way. Such changes should usually be detailed in the commit
+# that breaks the format and have been previously discussed on the mailing list
+# with general agreement from the core team.
+#
+OELAYOUT_ABI = "12"
+
+# add poky sanity bbclass
+INHERIT += "poky-sanity"
+
+# QA check settings - a little stricter than the OE-Core defaults
+WARN_TO_ERROR_QA = "already-stripped compile-host-path install-host-path \
+                    installed-vs-shipped ldflags pn-overrides rpaths staticdev \
+                    useless-rpaths"
+WARN_QA_remove = "${WARN_TO_ERROR_QA}"
+ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
+
+require conf/distro/include/poky-world-exclude.inc
+require conf/distro/include/no-static-libs.inc


### PR DESCRIPTION
This performs the same update of ptx.conf that the rocko branch got, but adds another bump to get the sumo version number (2.5)