### PR TITLE
dt-utils: update to 2019.01.0

### DIFF
--- a/recipes-core/dt-utils/dt-utils_2018.05.1.bb
+++ b/recipes-core/dt-utils/dt-utils_2018.05.1.bb
@@ -1,4 +1,0 @@
-require dt-utils.inc
-
-SRC_URI[md5sum] = "89d183f21fa76d4048a92bf638672442"
-SRC_URI[sha256sum] = "72415ebab43e76e625b24ffcf6477e0fd62f0e4c1f838c3bad48ee8b3b49fc8c"

--- a/recipes-core/dt-utils/dt-utils_2019.01.0.bb
+++ b/recipes-core/dt-utils/dt-utils_2019.01.0.bb
@@ -1,0 +1,4 @@
+require dt-utils.inc
+
+SRC_URI[md5sum] = "d83ebf99b07fa4516aeaa329afb2a6eb"
+SRC_URI[sha256sum] = "0905e183d82502f8ec6110b340bd8289ee8c0a048f214e50c5643ece352ce92b"


### PR DESCRIPTION
Please consider backporting this update at least to the "thud" branch as well.