### PR TITLE
barebox: add bison and flex build dependencies

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -11,7 +11,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit kernel-arch deploy
 inherit cml1
 
-DEPENDS = "libusb1-native lzop-native"
+DEPENDS = "libusb1-native lzop-native bison-native flex-native"
 
 PACKAGES += "${PN}-bareboxenv ${PN}-bareboxcrc32 ${PN}-kernel-install \
          ${PN}-bareboximd"


### PR DESCRIPTION
Both lex/yacc or compatibles are now dependencies of the barebox build
process, same as the kernel's. They are used since https://github.com/saschahauer/barebox/commit/273dbe5f87de8d6129a68ad40e87922fb6e783b6 contained
in barebox v2019.02.0 for generating the Kconfig lexer and parser.

Adding `flex-native` and `bison-native` to `DEPENDS` addresses this and fixes
the currently failing barebox v2019.02.0 `do_configure` stage:

	| DEBUG: Executing shell function do_configure
	| NOTE: make CROSS_COMPILE=arm-ptx-linux-gnueabi- oldconfig
	|   YACC    scripts/kconfig/zconf.tab.c
	| /bin/sh: 1: bison: not found
	| scripts/Makefile.lib:194: recipe for target 'scripts/kconfig/zconf.tab.c' failed
	| make[1]: *** [scripts/kconfig/zconf.tab.c] Error 127
	| Makefile:416: recipe for target 'oldconfig' failed
	| make: *** [oldconfig] Error 2

Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>