### PR TITLE
classes: genimage: depend on a different task of the used fs-image

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -85,7 +85,7 @@ GENIMAGE_IMAGE_LINK_NAME = "${IMAGE_BASENAME}-${MACHINE}"
 GENIMAGE_ROOTFS_IMAGE ?= ""
 GENIMAGE_ROOTFS_IMAGE_FSTYPE ?= "tar.bz2"
 
-do_genimage[depends] += "${@'${GENIMAGE_ROOTFS_IMAGE}:do_build' if '${GENIMAGE_ROOTFS_IMAGE}' else ''}"
+do_genimage[depends] += "${@'${GENIMAGE_ROOTFS_IMAGE}:do_image_complete' if '${GENIMAGE_ROOTFS_IMAGE}' else ''}"
 
 fakeroot do_genimage () {
     cd ${WORKDIR}


### PR DESCRIPTION
Depending on 'do_build' made a genimage recipe fail as the implicitely used
'staging.bbclass' tried to include the 'libgcc' package as well as the 'libgcc-
initial' package which contain conflicting files:

  ERROR: <RECIPENAME>-<VERSION> do_genimage: The file /usr/lib/<ARCH>-<DISTRO>-<ABI>/8.3.0/libgcc.a is installed by both libgcc-initial and libgcc, aborting
  ERROR: <RECIPENAME>-<VERSION> do_genimage:
  ERROR: <RECIPENAME>-<VERSION> do_genimage: Function failed: extend_recipe_sysroot
  ERROR: Logfile of failure stored in: <PATH_TO_BUILD_DIR>/tmp/work/<TUNEARCH>/<RECIPENAME>/<VERSION>/temp/log.do_genimage.19094
  ERROR: Task (<PATH_TO_BSP_DIR>/<META-LAYER>/recipes-core/images/<RECIPENAME>.bb:do_genimage) failed with exit code '1'

'staging.bbclass' is responsible for filling a recipe's individual sysroot using
the recipe's tracked dependencies. If 'do_genimage' depends on the utilized fs-
image's 'do_build' one finds a dependency to the fs-image's 'do_populate_sys-
root' task which later leads to the conflict. If 'do_genimage' instead depends
on the fs-image's task 'do_image_complete' then the problematic dependency to
'do_populate_sysroot' is avoided while the fs-image is still already created so
that it can be used by 'do_genimage'.

Signed-off-by: Ulrich Ölmann <u.oelmann@pengutronix.de>