### PR TITLE
barebox: update to v2019.05.0

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -4,7 +4,7 @@ SECTION = "bootloaders"
 PROVIDES = "virtual/bootloader"
 
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=057bf9e50e1ca857d0eb97bfe4ba8e5d"
+LIC_FILES_CHKSUM = "file://COPYING;md5=f5125d13e000b9ca1f0d3364286c4192"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 

--- a/recipes-bsp/barebox/barebox_2019.03.0.bb
+++ b/recipes-bsp/barebox/barebox_2019.03.0.bb
@@ -1,4 +1,0 @@
-require barebox.inc
-
-SRC_URI[md5sum] = "0b6fd3f04cb3e26276ae3cc20eed1bd7"
-SRC_URI[sha256sum] = "375a3010774cdd5169585d757b64c606288d6fce97f26b0b5f3d47319544b3f0"

--- a/recipes-bsp/barebox/barebox_2019.05.0.bb
+++ b/recipes-bsp/barebox/barebox_2019.05.0.bb
@@ -1,0 +1,4 @@
+require barebox.inc
+
+SRC_URI[md5sum] = "2e721cce90f1ea1492710ca23680311f"
+SRC_URI[sha256sum] = "704bb09b2bf1347e43ebb9138da32a7e1b4d13892fd187be98f4f9dae000501d"


### PR DESCRIPTION
Barebox' commit 0bb285926777 ("LICENSES: adopt Linux-like LICENSES directory
structure") which is part of barebox >= v2019.04.0 modified the file "COPYING"
so that its md5 hash had to be adjusted in the license information.

Signed-off-by: Ulrich Ölmann <u.oelmann@pengutronix.de>