### PR TITLE
bootspec: fix loader entry for dtbs in subdirs

### DIFF
--- a/classes/bootspec.bbclass
+++ b/classes/bootspec.bbclass
@@ -40,6 +40,7 @@ python create_bootspec() {
     bb.utils.mkdirhier(d.expand("${IMAGE_ROOTFS}/loader/entries/"))
 
     for x in dtb:
+        x = os.path.basename(x)
         bb.note("Creating boot spec entry /loader/entries/" + x + ".conf ...")
 
         try:


### PR DESCRIPTION
With the latest kernels like on arm64 machines the dts are
located in subdirectories. We have to remove any prefixes
for the loader entries.

Signed-off-by: Michael Grzeschik <m.grzeschik@pengutronix.de>