### PR TITLE
barebox: update LIC_FILES_CHKSUM

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -4,7 +4,7 @@ SECTION = "bootloaders"
 PROVIDES = "virtual/bootloader"
 
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=057bf9e50e1ca857d0eb97bfe4ba8e5d"
+LIC_FILES_CHKSUM = "file://COPYING;md5=f5125d13e000b9ca1f0d3364286c4192"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 


### PR DESCRIPTION
The COPYING file was changed with barebox v2019.04.0:

  https://git.pengutronix.de/cgit/barebox/commit/?id=0bb2859267779b9dc89fa078d7c0bcdbf32347b9

So reflect that change in LIC_FILES_CHKSUM.

Signed-off-by: Bastian Krause <bst@pengutronix.de>