### PR TITLE
distro/ptx.conf: align with poky zeus

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -1,7 +1,7 @@
 DISTRO = "ptx"
 DISTRO_NAME = "PTX - Poky (Yocto Project Reference Distro)"
-DISTRO_VERSION = "2.7-0"
-DISTRO_CODENAME = "ptx-warrior"
+DISTRO_VERSION = "3.0-0"
+DISTRO_CODENAME = "ptx-zeus"
 
 DISTROOVERRIDES =. "ptx:poky:"
 
@@ -18,7 +18,7 @@ PTX_DEFAULT_DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost wifi xattr 
 PTX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 PTX_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 
-DISTRO_FEATURES = "${DISTRO_FEATURES_LIBC} ${PTX_DEFAULT_DISTRO_FEATURES}"
+DISTRO_FEATURES = "${PTX_DEFAULT_DISTRO_FEATURES}"
 
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"


### PR DESCRIPTION
Remove deprecated DISTRO_FEATURES_LIBC according to upstream poky commit
5eb53830942141bfe57251dffecda36df90a62c1

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>