### PR TITLE
dt-utils: replace PN by BPN in SRC_URI

### DIFF
--- a/recipes-core/dt-utils/dt-utils.inc
+++ b/recipes-core/dt-utils/dt-utils.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9ac2e7cff1ddaf48b6eab6028f23ef88"
 DEPENDS = "udev"
 PR = "r0"
 
-SRC_URI = "http://www.pengutronix.de/software/dt-utils/download/${PN}-${PV}.tar.xz"
+SRC_URI = "http://www.pengutronix.de/software/dt-utils/download/${BPN}-${PV}.tar.xz"
 
 inherit autotools pkgconfig gettext
 


### PR DESCRIPTION
PN may contain common prefixes as -native or nativesdk- and is thus
inappropriate for SRC_URI. Replace by BPN which has these prefixes
removed.

This also fixes QA issue:

| do_package_qa: QA Issue: dt-utils: SRC_URI uses PN not BPN [src-uri-bad]

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>