### PR TITLE
distro/ptx.conf: do not set special TARGET_VENDOR

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -7,8 +7,6 @@ DISTROOVERRIDES =. "ptx:poky:"
 
 MAINTAINER = "Pengutronix <ptx@pengutronix.de>"
 
-TARGET_VENDOR = "-ptx"
-
 LOCALCONF_VERSION = "1"
 
 DISTRO_VERSION[vardepsexclude] = "DATE"


### PR DESCRIPTION
Setting a custom TARGET_VENDOR will not have any benefit here except for
having a 'ptx'-named toolchain generated. But instead it will prevent us
from allowing to reuse standard/common sstate cache when having this distro
enabled.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>