### PR TITLE
add ptx-profile package only when 'ptx' distro is active

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -13,7 +13,7 @@ DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 # Override these in ptx based distros
 PTX_DEFAULT_DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost wifi xattr nfs zeroconf multiarch systemd"
-PTX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
+PTX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot ptx-profile"
 PTX_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 
 DISTRO_FEATURES = "${PTX_DEFAULT_DISTRO_FEATURES}"

--- a/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS_${PN} += "ptx-profile"


### PR DESCRIPTION
The ptx layer should not unconditionally manipulate any existing package
to be compatible with the default YP guidelines.

To have ptx-profile only active when 'ptx' distro is selected, we add it
via `DISTRO_EXTRA_RDEPENDS`. So it will make its way into images that use
`packagegroup-base`, which is recommended, anyway.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>