### PR TITLE
dt-utils: perform manual package split to avoid dbg package collisions

### DIFF
--- a/recipes-core/dt-utils/dt-utils.inc
+++ b/recipes-core/dt-utils/dt-utils.inc
@@ -10,8 +10,13 @@ SRC_URI = "http://www.pengutronix.de/software/dt-utils/download/${BPN}-${PV}.tar
 
 inherit autotools pkgconfig gettext
 
-PACKAGES =+ "${PN}-barebox-state ${PN}-fdtdump ${PN}-dtblint"
+PACKAGES =+ "${PN}-barebox-state ${PN}-barebox-state-dbg ${PN}-fdtdump ${PN}-fdtdump-dbg ${PN}-dtblint ${PN}-dtblint-dbg"
 
+NOAUTOPACKAGEDEBUG = "1"
 FILES_${PN}-barebox-state = "${bindir}/barebox-state"
+FILES_${PN}-barebox-state-dbg = "${bindir}/.debug/barebox-state"
 FILES_${PN}-fdtdump = "${bindir}/fdtdump"
+FILES_${PN}-fdtdump-dbg = "${bindir}/.debug/fdtdump"
 FILES_${PN}-dtblint = "${bindir}/dtblint"
+FILES_${PN}-dtblint-dbg = "${bindir}/.debug/dtblint"
+FILES_${PN}-dbg = "${libdir}/.debug/"


### PR DESCRIPTION
By default, all debug symbols will end up in runtime package ${PN}-dbg,
even if the binaries are split into several runtime packages.

In most cases it is not an issue to install all non-relevant debug package
unconditionally. But as the 'dt-utils' package provides the 'fdtdump'
utility that the 'dtc' package also provides, this would trigger a -dbg
package collision when attempting to install both any of the dt-utils runtime
package and any of the dtc runtime packages:

| Error: Transaction check error:
|   file /usr/bin/.debug/fdtdump conflicts between attempted installs of libdt-utils-dbg-2019.01.0-r0.corei7_64 and dtc-dbg-1.5.1-r0.corei7_64

To prevent this, we simply disable the default debug package split and
perform it on our own by splitting the debug symbols into a
runtime package-specific dbg package.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>