### PR TITLE
distro/ptx.conf: add 'usrmerge' to default distro features

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -12,7 +12,7 @@ LOCALCONF_VERSION = "1"
 DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 # Override these in ptx based distros
-PTX_DEFAULT_DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost wifi xattr nfs zeroconf multiarch systemd"
+PTX_DEFAULT_DISTRO_FEATURES = "argp ext2 largefile usbgadget usbhost wifi xattr nfs zeroconf multiarch systemd usrmerge"
 PTX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot ptx-profile"
 PTX_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 


### PR DESCRIPTION
Use the usrmerge DISTRO feature to get rid of historical separations of
/bin and /usr/bin (/lib and /usr/lib, etc.).

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>