### PR TITLE
barebox: also use image suffix for barebox-flash-image and EFI

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -119,10 +119,10 @@ do_deploy[vardepsexclude] = "DATETIME"
 do_deploy () {
 	install -d ${DEPLOYDIR}
 	if [ -e ${B}/barebox-flash-image ]; then
-		install -m 644 -t ${DEPLOYDIR}/ ${B}/barebox-flash-image
+		install -m 644 -T ${B}/barebox-flash-image ${DEPLOYDIR}/barebox-flash-image${BAREBOX_IMAGE_SUFFIX}
 	fi
 	if [ -e ${B}/barebox.efi ]; then
-		install -m 644 -t ${DEPLOYDIR}/ ${B}/barebox.efi
+		install -m 644 -T ${B}/barebox.efi ${DEPLOYDIR}/barebox.efi${BAREBOX_IMAGE_SUFFIX}
 	fi
 	for IMAGE in ${BAREBOX_IMAGES_TO_DEPLOY}; do
 		if [ -e ${IMAGE} ]; then


### PR DESCRIPTION
This makes it possible to have multiple barebox packages in a BSP without them overwriting each other's image in the deploy stage, even when they're building an EFI image or only a `barebox-flash-image`.