### PR TITLE
barebox: prevent BAREBOX_IMAGES check from failing unintentionally

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -104,7 +104,7 @@ do_deploy () {
 			ln -sf ${BAREBOX_IMG_BASENAME}-${DATETIME}.img ${DEPLOYDIR}/${BAREBOX_IMG_BASENAME}.img
 		else
 			# Throw an error if the user specified image(s) can't be installed
-			[ "${BAREBOX_IMAGES}" != "*.img" ] && bberror "Image ${IMAGE} not found"
+			[ "${BAREBOX_IMAGES}" != "*.img" ] && bberror "Image ${IMAGE} not found" || true
 		fi
 	done
 }


### PR DESCRIPTION
The intention of the statement was to trigger a bberror if
no image could be found and ${BAREBOX_IMAGES} contains anything else
than the default glob '*.img'.
However, when the first expression evaluates to false and thus not
triggers the bberror, it will, in turn, let the script silently fail with
exit 1 which is not the intention here.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>