### PR TITLE
barebox: allows building standard defconfig

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -20,7 +20,7 @@ SRC_URI = "http://barebox.org/download/barebox-${PV}.tar.bz2"
 
 S = "${WORKDIR}/barebox-${PV}"
 
-COMPATIBLE_MACHINE = "none"
+BAREBOX_CONFIG ?= ""
 
 EXTRA_OEMAKE = "CROSS_COMPILE=${TARGET_PREFIX}"
 
@@ -28,7 +28,11 @@ do_configure() {
 	if [ -e ${WORKDIR}/defconfig ]; then
 		cp ${WORKDIR}/defconfig ${S}/.config
 	else
-		bbwarn "No defconfig given"
+		if [ -n "${BAREBOX_CONFIG}" ]; then
+			oe_runmake ${BAREBOX_CONFIG}
+		else
+			bbfatal "No defconfig given. Either add file 'file://defconfig' to SRC_URI or set BAREBOX_CONFIG"
+		fi
 	fi
 
 	cml1_do_configure


### PR DESCRIPTION
With setting BAREBOX_CONFIG, e.g

```
BAREBOX_CONFIG = "efi_defconfig"
```

we can now let barebox build without having to specify a 'defconfig'
file explicitly.

Also, change the warning about non-existing defconfig to be fatal and
provide in turn more helpful error message.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>