### PR TITLE
barebox: populate new BUILDSYSTEM_VERSION option

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -23,8 +23,6 @@ B = "${WORKDIR}/build"
 
 BAREBOX_CONFIG ?= ""
 
-EXTRA_OEMAKE = "CROSS_COMPILE=${TARGET_PREFIX} -C ${S} O=${B}"
-
 def find_cfgs(d):
     sources=src_patches(d, True)
     sources_list=[]
@@ -33,6 +31,20 @@ def find_cfgs(d):
             sources_list.append(s)
 
     return sources_list
+
+def get_layer_rev(path):
+    try:
+        rev, _ = bb.process.run("git describe --match='' --always --dirty --broken", cwd=path)
+    except bb.process.ExecutionError:
+        rev = ""
+    return rev.strip()
+
+BAREBOX_BUILDSYSTEM_VERSION ??= "${@get_layer_rev(os.path.dirname(d.getVar('FILE')))}"
+
+EXTRA_OEMAKE = " \
+  CROSS_COMPILE=${TARGET_PREFIX} -C ${S} O=${B} \
+  BUILDSYSTEM_VERSION=${BAREBOX_BUILDSYSTEM_VERSION} \
+"
 
 do_configure() {
 	if [ -e ${WORKDIR}/defconfig ]; then


### PR DESCRIPTION
```
Since v2020.11.0 barebox now supports a make BUILDSYSTEM_VERSION= option
that allows embedding a string into the barebox binary that is printed
to console and readable in barebox and Linux via imd.

This is useful because the barebox release may not reflect auxiliary
information like the configuration and the built-in environment.

Populate this variable with the git commit-ish of the git repository
containing the barebox recipe. If there's none, an empty string is
passed, which is the default behavior.

This can be enabled unconditionally for older barebox versions as well,
because unknown make variables are ignored.

Recipes that want to customize the version, can override
BAREBOX_BUILDSYSTEM_VERSION to their preferred value.

Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
```