### PR TITLE
genimage: inherit image-artifact-names

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -62,6 +62,8 @@
 # GENIMAGE_ROOTFS_IMAGE - input rootfs image to generate file system images from
 # GENIMAGE_ROOTFS_IMAGE_FSTYPE	- input roofs FSTYPE to use (default: 'tar.bz2')
 
+inherit image-artifact-names
+
 LICENSE = "MIT"
 PACKAGES = ""
 


### PR DESCRIPTION
Commit 43f1cf2d3d4b ("image-artifact-names: introduce new bbclass and
move some variables into it") within poky moved the IMAGE_BASENAME from
the bitbake.conf to the image-artifact-names bbclass. Since genimage
uses IMAGE_BASENAME, inherit image-artifact-names.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>