### PR TITLE
distro/ptx.conf: update to gatesgarth (3.2)

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -1,7 +1,7 @@
 DISTRO = "ptx"
 DISTRO_NAME = "PTX - Poky (Yocto Project Reference Distro)"
-DISTRO_VERSION = "3.1-0"
-DISTRO_CODENAME = "ptx-dunfell"
+DISTRO_VERSION = "3.2-0"
+DISTRO_CODENAME = "ptx-gatesgarth"
 
 DISTROOVERRIDES =. "ptx:poky:"
 


### PR DESCRIPTION
No changes necessary otherwise since the poky config did not change much
from dunfell to gatesgarth.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>

Also requesting a backport to gatesgarth.