### PR TITLE
barebox: update to 2020.11.0

### DIFF
--- a/recipes-bsp/barebox/barebox_2019.05.0.bb
+++ b/recipes-bsp/barebox/barebox_2019.05.0.bb
@@ -1,4 +1,0 @@
-require barebox.inc
-
-SRC_URI[md5sum] = "2e721cce90f1ea1492710ca23680311f"
-SRC_URI[sha256sum] = "704bb09b2bf1347e43ebb9138da32a7e1b4d13892fd187be98f4f9dae000501d"

--- a/recipes-bsp/barebox/barebox_2020.11.0.bb
+++ b/recipes-bsp/barebox/barebox_2020.11.0.bb
@@ -1,0 +1,3 @@
+require barebox.inc
+
+SRC_URI[sha256sum] = "049d2b1b887d0397f4b5390255459fb0240200b06a3276ffaefdeab7fb243554"


### PR DESCRIPTION
Also drop the legacy md5sum SRC_URI hash.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>