### PR TITLE
genimage: add deploy task after genimage

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -62,7 +62,7 @@
 # GENIMAGE_ROOTFS_IMAGE - input rootfs image to generate file system images from
 # GENIMAGE_ROOTFS_IMAGE_FSTYPE	- input roofs FSTYPE to use (default: 'tar.bz2')
 
-inherit image-artifact-names
+inherit image-artifact-names deploy
 
 LICENSE = "MIT"
 PACKAGES = ""
@@ -70,6 +70,8 @@ PACKAGES = ""
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 S = "${WORKDIR}"
+
+B = "${WORKDIR}/genimage-${PN}"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
@@ -90,7 +92,7 @@ do_genimage[depends] += "${@'${GENIMAGE_ROOTFS_IMAGE}:do_image_complete' if '${G
 GENIMAGE_TMPDIR  = "${WORKDIR}/genimage-tmp"
 GENIMAGE_ROOTDIR  = "${WORKDIR}/root"
 
-do_genimage[cleandirs] = "${GENIMAGE_TMPDIR} ${GENIMAGE_ROOTDIR} ${DEPLOYDIR}"
+do_genimage[cleandirs] = "${GENIMAGE_TMPDIR} ${GENIMAGE_ROOTDIR}"
 
 do_configure () {
     if grep -vq "@IMAGE@" ${WORKDIR}/genimage.config; then
@@ -101,16 +103,7 @@ do_configure () {
 }
 
 DEPLOYDIR = "${WORKDIR}/deploy-${PN}"
-SSTATETASKS += "do_genimage"
-do_genimage[sstate-inputdirs] = "${DEPLOYDIR}"
-do_genimage[sstate-outputdirs] = "${DEPLOY_DIR_IMAGE}"
-
-python do_genimage_setscene () {
-    sstate_setscene(d)
-}
-addtask do_genimage_setscene
-do_genimage[dirs] = "${DEPLOYDIR} ${B}"
-do_genimage[stamp-extra-info] = "${MACHINE_ARCH}"
+do_genimage[dirs] = "${B}"
 
 fakeroot do_genimage () {
 
@@ -127,15 +120,24 @@ fakeroot do_genimage () {
         --config ${B}/.config.tmp \
         --tmppath ${GENIMAGE_TMPDIR} \
         --inputpath ${DEPLOY_DIR_IMAGE} \
-        --outputpath ${DEPLOYDIR} \
+        --outputpath ${B} \
         --rootpath ${GENIMAGE_ROOTDIR}
 
     rm ${B}/.config.tmp
+}
+do_genimage[depends] += "virtual/fakeroot-native:do_populate_sysroot"
+
+addtask genimage after do_configure before do_build
+
+do_deploy () {
+    install ${B}/* ${DEPLOYDIR}/
 
     if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_NAME}.${GENIMAGE_IMAGE_SUFFIX} ]; then
         ln -sf ${GENIMAGE_IMAGE_NAME}.${GENIMAGE_IMAGE_SUFFIX} ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_NAME}.${GENIMAGE_IMAGE_SUFFIX}
     fi
 }
+
+addtask deploy after do_genimage before do_build
 
 do_patch[noexec] = "1"
 do_compile[noexec] = "1"
@@ -148,4 +150,3 @@ deltask do_package_write_ipk
 deltask do_package_write_deb
 deltask do_package_write_rpm
 
-addtask genimage after do_configure before do_build


### PR DESCRIPTION
Instead of coding the deployment into the genimage task, use genimage as
a separate task which will only create the requested image, instead of
directly copying it into the ${DEPLOYDIR}. This is necessary since
fakeroot tasks add to the SSTATE, will try to record the uid and gid of
the files, however since PSEUDO_IGNORE_PATH was introduced into oe-core,
files within the deploy directory are ignored. This leads to an error
when trying to add files from the ${DEPLOYDIR} into the SSTATE:

```
  WARNING: simple-sd-image-1.0-r0 do_genimage: KeyError in ./deploy-simple-sd-image
  File: '/home/phoenix/build/YOCTO.BSP-Pengutronix-OP-TEE/meta/lib/oe/sstatesig.py', lineno: 592, function: OEOuthashBasic
       0588:
       0589:                update_hash("\n")
       0590:
       0591:            # Process this directory and all its child files
   *** 0592:            process(root)
       0593:            for f in files:
       0594:                if f == 'fixmepath':
       0595:                    continue
       0596:                process(os.path.join(root, f))
  File: '/home/phoenix/build/YOCTO.BSP-Pengutronix-OP-TEE/meta/lib/oe/sstatesig.py', lineno: 555, function: process
       0551:                    add_perm(stat.S_IXOTH, 'x')
       0552:
       0553:                if include_owners:
       0554:                    try:
   *** 0555:                        update_hash(" %10s" % pwd.getpwuid(s.st_uid).pw_name)
       0556:                        update_hash(" %10s" % grp.getgrgid(s.st_gid).gr_name)
       0557:                    except KeyError:
       0558:                        bb.warn("KeyError in %s" % path)
       0559:                        raise
  Exception: KeyError: 'getpwuid(): uid not found: 1000'
```

We copy every generated image to the deploy directory to not break
the existing behaviour, where genimage generated every image file in the
deploy directory directly.

Fixes https://github.com/pengutronix/meta-ptx/issues/60

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>