### PR TITLE
barebox: unbreak defaultenv for master

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -65,8 +65,8 @@ do_compile () {
 	# If there is an 'env' directory, append its content
 	# to the compiled environment
 	if [ -d ${WORKDIR}/env/ ]; then \
-		mkdir -p ${B}/.yocto-defaultenv
-		cp -r ${WORKDIR}/env/* ${B}/.yocto-defaultenv/; \
+		mkdir -p ${S}/.yocto-defaultenv
+		cp -r ${WORKDIR}/env/* ${S}/.yocto-defaultenv/; \
 		grep -q .yocto-defaultenv ${B}/.config || \
 	        sed -i -e "s,^\(CONFIG_DEFAULT_ENVIRONMENT_PATH=.*\)\"$,\1 .yocto-defaultenv\"," \
 		                ${B}/.config; \


### PR DESCRIPTION
Barebox expects the default environment files in the Source repository,
not the build repository. While this indicates a bug within barebox, we
should still allow includation of the default environment pending a fix.
Copy the default environment into the source directory instead of the
build directory.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>