### PR TITLE
genimage: clean up after inheriting deploy class

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -102,7 +102,6 @@ do_configure () {
     cp ${WORKDIR}/genimage.config ${B}/.config
 }
 
-DEPLOYDIR = "${WORKDIR}/deploy-${PN}"
 do_genimage[dirs] = "${B}"
 
 fakeroot do_genimage () {


### PR DESCRIPTION
`DEPLOYDIR` is already set in the [deploy class](http://cgit.openembedded.org/openembedded-core/tree/meta/classes/deploy.bbclass?id=ecb038f14c0b91280ba1532ad94a6ebc64c70644#n1), but was not removed in
meta-ptx' commit 9eaa29b7d0f0. So clean it up now.