### PR TITLE
dt-utils: update to 2021.03.0

### DIFF
--- a/recipes-core/dt-utils/dt-utils_2019.01.0.bb
+++ b/recipes-core/dt-utils/dt-utils_2019.01.0.bb
@@ -1,4 +1,0 @@
-require dt-utils.inc
-
-SRC_URI[md5sum] = "d83ebf99b07fa4516aeaa329afb2a6eb"
-SRC_URI[sha256sum] = "0905e183d82502f8ec6110b340bd8289ee8c0a048f214e50c5643ece352ce92b"

--- a/recipes-core/dt-utils/dt-utils_2021.03.0.bb
+++ b/recipes-core/dt-utils/dt-utils_2021.03.0.bb
@@ -1,0 +1,4 @@
+require dt-utils.inc
+
+SRC_URI[md5sum] = "acf0b5e3b18e40e6172b67fbad2e52fb"
+SRC_URI[sha256sum] = "36a56924e356250988315cd8761fde52832e6d4934323aca2827ff93fa12907f"


### PR DESCRIPTION
Not sure what to do about the new `--enable-state-backward-compatibility` configure option, I guess every BSP maintainer would need to set this in a bbappend…?