### PR TITLE
distro: update to hardknott

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -1,7 +1,7 @@
 DISTRO = "ptx"
 DISTRO_NAME = "PTX - Poky (Yocto Project Reference Distro)"
-DISTRO_VERSION = "3.2-0"
-DISTRO_CODENAME = "ptx-gatesgarth"
+DISTRO_VERSION = "3.3-0"
+DISTRO_CODENAME = "ptx-hardknott"
 
 DISTROOVERRIDES =. "ptx:poky:"
 


### PR DESCRIPTION
Poky config did not change from gatesgarth to hardknott.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>