### PR TITLE
genimage.bbclass: add bmaptool support

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -84,6 +84,9 @@ GENIMAGE_IMAGE_NAME = "${IMAGE_BASENAME}-${MACHINE}-${DATETIME}"
 GENIMAGE_IMAGE_NAME[vardepsexclude] = "DATETIME"
 GENIMAGE_IMAGE_LINK_NAME = "${IMAGE_BASENAME}-${MACHINE}"
 
+GENIMAGE_IMAGE_FULLNAME ?= "${GENIMAGE_IMAGE_NAME}.${GENIMAGE_IMAGE_SUFFIX}"
+GENIMAGE_IMAGE_LINK_FULLNAME ?= "${GENIMAGE_IMAGE_LINK_NAME}.${GENIMAGE_IMAGE_SUFFIX}"
+
 GENIMAGE_ROOTFS_IMAGE ?= ""
 GENIMAGE_ROOTFS_IMAGE_FSTYPE ?= "tar.bz2"
 
@@ -103,7 +106,7 @@ do_configure () {
 do_genimage[dirs] = "${B}"
 
 fakeroot do_genimage () {
-    sed s:@IMAGE@:${GENIMAGE_IMAGE_NAME}.${GENIMAGE_IMAGE_SUFFIX}:g ${WORKDIR}/genimage.config > ${B}/.config
+    sed s:@IMAGE@:${GENIMAGE_IMAGE_FULLNAME}:g ${WORKDIR}/genimage.config > ${B}/.config
 
     # unpack input rootfs image if given
     if [ "x${GENIMAGE_ROOTFS_IMAGE}" != "x" ]; then
@@ -128,8 +131,8 @@ addtask genimage after do_configure before do_build
 do_deploy () {
     install ${B}/* ${DEPLOYDIR}/
 
-    if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_NAME}.${GENIMAGE_IMAGE_SUFFIX} ]; then
-        ln -sf ${GENIMAGE_IMAGE_NAME}.${GENIMAGE_IMAGE_SUFFIX} ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_NAME}.${GENIMAGE_IMAGE_SUFFIX}
+    if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_FULLNAME} ]; then
+        ln -sf ${GENIMAGE_IMAGE_FULLNAME} ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_FULLNAME}
     fi
 }
 

--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -92,6 +92,9 @@ GENIMAGE_ROOTFS_IMAGE_FSTYPE ?= "tar.bz2"
 
 do_genimage[depends] += "${@'${GENIMAGE_ROOTFS_IMAGE}:do_image_complete' if '${GENIMAGE_ROOTFS_IMAGE}' else ''}"
 
+GENIMAGE_CREATE_BMAP ?= "0"
+do_genimage[depends] += "${@'bmap-tools-native:do_populate_sysroot' if d.getVar('GENIMAGE_CREATE_BMAP') == '1' else ''}"
+
 GENIMAGE_TMPDIR  = "${WORKDIR}/genimage-tmp"
 GENIMAGE_ROOTDIR  = "${WORKDIR}/root"
 
@@ -122,6 +125,10 @@ fakeroot do_genimage () {
         --outputpath ${B} \
         --rootpath ${GENIMAGE_ROOTDIR}
 
+    if [ "${GENIMAGE_CREATE_BMAP}" = 1 ] ; then
+        bmaptool create -o ${B}/${GENIMAGE_IMAGE_FULLNAME}.bmap ${B}/${GENIMAGE_IMAGE_FULLNAME}
+    fi
+
     rm ${B}/.config
 }
 do_genimage[depends] += "virtual/fakeroot-native:do_populate_sysroot"
@@ -134,6 +141,10 @@ do_deploy () {
     if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_FULLNAME} ]; then
         ln -sf ${GENIMAGE_IMAGE_FULLNAME} ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_FULLNAME}
     fi
+    if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_FULLNAME}.bmap ] ; then
+        ln -sf ${GENIMAGE_IMAGE_FULLNAME}.bmap ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_FULLNAME}.bmap
+    fi
+
 }
 
 addtask deploy after do_genimage before do_build


### PR DESCRIPTION
Allow creating a `.bmap` metadata file for use with bmaptool.