### PR TITLE
genimage:  update to v14

### DIFF
--- a/recipes-devtools/genimage/genimage_13.bb
+++ b/recipes-devtools/genimage/genimage_13.bb
@@ -1,4 +1,0 @@
-require genimage.inc
-
-SRC_URI[md5sum] = "84ec07d684f27a425b3789f87c35ffa3"
-SRC_URI[sha256sum] = "4206e253226a384386c01591251f2ed1ea3485ef63f1e696db03600e1213db79"

--- a/recipes-devtools/genimage/genimage_14.bb
+++ b/recipes-devtools/genimage/genimage_14.bb
@@ -1,0 +1,3 @@
+require genimage.inc
+
+SRC_URI[sha256sum] = "9d1d53b33309fe24ea367ea057eb689bdb8ea33cb99d796de31127ca44ccf44c"


### PR DESCRIPTION
I am using this for the new android-sparse image type support, works
nicely.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>