### PR TITLE
genimage.bbclass: fix grep usage in do_configure

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -95,7 +95,7 @@ GENIMAGE_ROOTDIR  = "${WORKDIR}/root"
 do_genimage[cleandirs] = "${GENIMAGE_TMPDIR} ${GENIMAGE_ROOTDIR} ${B}"
 
 do_configure () {
-    if grep -vq "@IMAGE@" ${WORKDIR}/genimage.config; then
+    if ! grep -q "@IMAGE@" ${WORKDIR}/genimage.config; then
         bbnote "genimage.config does not contain @IMAGE@ marker"
     fi
 }


### PR DESCRIPTION
The bbnote is currently emitted whenever genimage.config has at least
one line not containing @IMAGE@, i.e. effectively always. Fix the
logic so it is emitted if genimage.config doesn't have at least one
line containing @IMAGE@ as intended.