### PR TITLE
barebox: introduce BAREBOX_FIRMWARE_DIR

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -61,6 +61,9 @@ do_configure() {
 	cml1_do_configure
 }
 
+BAREBOX_FIRMWARE_DIR ?= ""
+BAREBOX_FIRMWARE_DIR[doc] = "Overwrite barebox' firmware blobs search directory (CONFIG_EXTRA_FIRMWARE_DIR) with this path"
+
 do_compile () {
 	# If there is an 'env' directory, append its content
 	# to the compiled environment
@@ -71,6 +74,12 @@ do_compile () {
 	        sed -i -e "s,^\(CONFIG_DEFAULT_ENVIRONMENT_PATH=.*\)\"$,\1 .yocto-defaultenv\"," \
 		                ${B}/.config; \
 
+	fi
+
+	# If ${BAREBOX_FIRMWARE_DIR} is set, use that for CONFIG_EXTRA_FIRMWARE_DIR
+	if [ -n "${BAREBOX_FIRMWARE_DIR}" ]; then
+		sed -i -e "s,^\(CONFIG_EXTRA_FIRMWARE_DIR=\"\).*\"$,\1${BAREBOX_FIRMWARE_DIR}\"," \
+				${B}/.config
 	fi
 
 	# Barebox uses pkg-config only for building native tools


### PR DESCRIPTION
If `BAREBOX_FIRMWARE_DIR` is set, barebox' `CONFIG_EXTRA_FIRMWARE_DIR` is set to its value. Note that the original value of `CONFIG_EXTRA_FIRMWARE_DIR` is overwritten in that case.

This allows setting the firmware search path directly without the need of copying firmware files around, e.g.:
```
BAREBOX_FIRMWARE_DIR = "${STAGING_DIR_TARGET}/firmware"
```

Currently (v2021.06.0) the imxcfg directive `signed_hdmi_firmware` does not consider `CONFIG_EXTRA_FIRMWARE_DIR`, so setting `BAREBOX_FIRMWARE_DIR` does not affect that. A possible workaround is:
```
BAREBOX_FIRMWARE_DIR = "${B}/firmware"

do_compile_prepend() {
    mkdir -p ${BAREBOX_FIRMWARE_DIR}
    cp ${DEPLOY_DIR_IMAGE}/signed_hdmi_imx8m.bin ${BAREBOX_FIRMWARE_DIR}
}
```
This works because `signed_hdmi_firmware` also expects the firmware in `${B}/firmware`. Note that other needed firmware files need to be copied to the same destination.