### PR TITLE
barebox: use KBUILD_USERCFLAGS to set userccflags

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -88,7 +88,7 @@ do_compile () {
 	export PKG_CONFIG_PATH="${STAGING_DIR_NATIVE}"
 
 	export TARGETCFLAGS="${TARGET_LDFLAGS}${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
-	export userccflags="${TARGETCFLAGS}"
+	export KBUILD_USERCFLAGS="${TARGETCFLAGS}"
 	unset LDFLAGS
 	unset CFLAGS
 	unset CPPFLAGS


### PR DESCRIPTION
According to [1], userccflags is the variable used by makefiles to
modify the CFLAGS for user programs. To set the user program CFLAGS
outside of the Makefile, KBUILD_USERCFLAGS should be used. Replace
userccflags with KBUILD_USERCFLAGS.

[1]: https://www.kernel.org/doc/html/latest/kbuild/makefiles.html#controlling-compiler-options-for-userspace-programs

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

Opening as draft since I haven't tested this.