### PR TITLE
barebox: remove TARGETCFLAGS

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -87,8 +87,7 @@ do_compile () {
 	export PKG_CONFIG_SYSROOT_DIR=
 	export PKG_CONFIG_PATH="${STAGING_DIR_NATIVE}"
 
-	export TARGETCFLAGS="${TARGET_LDFLAGS}${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
-	export userccflags="${TARGETCFLAGS}"
+	export userccflags="${TARGET_LDFLAGS}${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
 	unset LDFLAGS
 	unset CFLAGS
 	unset CPPFLAGS


### PR DESCRIPTION
As promised [here](https://github.com/pengutronix/meta-ptx/pull/74#issuecomment-883540834) clean up ``TARGETCFLAGS`` now as they are of no use anymore for current barebox releases (starting with v2020.08.0).