### PR TITLE
genimage.bbclass: support compressing the generated image

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -64,6 +64,8 @@
 # GENIMAGE_ROOTFS_IMAGE - input rootfs image to generate file system images from
 # GENIMAGE_ROOTFS_IMAGE_FSTYPE	- input roofs FSTYPE to use (default: 'tar.bz2')
 # GENIMAGE_VARIABLES[VAR]	- replace @VAR@ in config with variable flag value
+# GENIMAGE_COMPRESSION - compress the generated image. Allowed values
+# are 'none' for no compression (the default), 'gzip' and 'xz'.
 
 inherit image-artifact-names deploy
 
@@ -102,6 +104,18 @@ do_genimage[depends] += "${@'${GENIMAGE_ROOTFS_IMAGE}:do_image_complete' if '${G
 
 GENIMAGE_CREATE_BMAP ?= "0"
 do_genimage[depends] += "${@'bmap-tools-native:do_populate_sysroot' if d.getVar('GENIMAGE_CREATE_BMAP') == '1' else ''}"
+
+GENIMAGE_COMPRESSION ??= "none"
+
+GENIMAGE_COMPRESS_DEPENDS[none] = ""
+GENIMAGE_COMPRESS_DEPENDS[gzip] = "pigz-native:do_populate_sysroot"
+GENIMAGE_COMPRESS_DEPENDS[xz]   = "xz-native:do_populate_sysroot"
+do_genimage[depends] += "${@d.getVarFlag('GENIMAGE_COMPRESS_DEPENDS', ${GENIMAGE_COMPRESSION})}"
+
+GENIMAGE_COMPRESS_CMD[none] = ":"
+GENIMAGE_COMPRESS_CMD[gzip] = "gzip -f -9 -n"
+GENIMAGE_COMPRESS_CMD[xz]   = "xz -f"
+GENIMAGE_COMPRESS_CMD = "${@d.getVarFlag('GENIMAGE_COMPRESS_CMD', ${GENIMAGE_COMPRESSION})}"
 
 GENIMAGE_TMPDIR  = "${WORKDIR}/genimage-tmp"
 GENIMAGE_ROOTDIR  = "${WORKDIR}/root"
@@ -155,6 +169,8 @@ fakeroot do_genimage () {
     if [ "${GENIMAGE_CREATE_BMAP}" = 1 ] ; then
         bmaptool create -o ${B}/${GENIMAGE_IMAGE_FULLNAME}.bmap ${B}/${GENIMAGE_IMAGE_FULLNAME}
     fi
+
+    ${GENIMAGE_COMPRESS_CMD} ${B}/${GENIMAGE_IMAGE_FULLNAME}
 
     rm ${B}/.config
 }


### PR DESCRIPTION
I don't know if using the extension as the key for requesting
compression is the best thing to do, but it does make the change in
the do_deploy() task rather simple.

We cannot include the extension in GENIMAGE_IMAGE_FULLNAME, because
the image must initially be generated using that name, and the .bmap
file (if requested) generated from that.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>