### PR TITLE
Compose the default environment from multiple env* directories

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -11,7 +11,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit kernel-arch deploy
 inherit cml1
 
-DEPENDS = "libusb1-native lzop-native bison-native flex-native"
+DEPENDS = "libusb1-native lzop-native bison-native flex-native rsync-native"
 
 PACKAGES += "${PN}-bareboxenv ${PN}-bareboxcrc32 ${PN}-kernel-install \
          ${PN}-bareboximd"
@@ -55,7 +55,15 @@ do_configure() {
 		bbfatal "No defconfig given. Either add file 'file://defconfig' to SRC_URI or set BAREBOX_CONFIG"
 	fi
 
-	${S}/scripts/kconfig/merge_config.sh -m .config ${@" ".join(find_cfgs(d))}
+	# Merge 'env*' directories into the compiled environment
+	mkdir -p ${S}/.defaultenv
+	find ${WORKDIR} -mindepth 1 -maxdepth 1 -type d -name 'env*' -execdir rsync -av '{}/' ${S}/.defaultenv ';'
+	echo "CONFIG_DEFAULT_ENVIRONMENT_PATH=\"${S}/.defaultenv\"" > ${B}/.defaultenv.cfg
+
+	${S}/scripts/kconfig/merge_config.sh -m ${B}/.config \
+		${B}/.defaultenv.cfg \
+		${@" ".join(find_cfgs(d))}
+
 	cml1_do_configure
 }
 
@@ -63,17 +71,6 @@ BAREBOX_FIRMWARE_DIR ?= ""
 BAREBOX_FIRMWARE_DIR[doc] = "Overwrite barebox' firmware blobs search directory (CONFIG_EXTRA_FIRMWARE_DIR) with this path"
 
 do_compile () {
-	# If there is an 'env' directory, append its content
-	# to the compiled environment
-	if [ -d ${WORKDIR}/env/ ]; then \
-		mkdir -p ${S}/.yocto-defaultenv
-		cp -r ${WORKDIR}/env/* ${S}/.yocto-defaultenv/; \
-		grep -q .yocto-defaultenv ${B}/.config || \
-	        sed -i -e "s,^\(CONFIG_DEFAULT_ENVIRONMENT_PATH=.*\)\"$,\1 .yocto-defaultenv\"," \
-		                ${B}/.config; \
-
-	fi
-
 	# If ${BAREBOX_FIRMWARE_DIR} is set, use that for CONFIG_EXTRA_FIRMWARE_DIR
 	if [ -n "${BAREBOX_FIRMWARE_DIR}" ]; then
 		sed -i -e "s,^\(CONFIG_EXTRA_FIRMWARE_DIR=\"\).*\"$,\1${BAREBOX_FIRMWARE_DIR}\"," \

--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -46,6 +46,9 @@ EXTRA_OEMAKE = " \
   BUILDSYSTEM_VERSION=${BAREBOX_BUILDSYSTEM_VERSION} \
 "
 
+BAREBOX_FIRMWARE_DIR ?= ""
+BAREBOX_FIRMWARE_DIR[doc] = "Overwrite barebox' firmware blobs search directory (CONFIG_EXTRA_FIRMWARE_DIR) with this path"
+
 do_configure() {
 	if [ -e ${WORKDIR}/defconfig ]; then
 		cp ${WORKDIR}/defconfig ${B}/.config
@@ -60,23 +63,21 @@ do_configure() {
 	find ${WORKDIR} -mindepth 1 -maxdepth 1 -type d -name 'env*' -execdir rsync -av '{}/' ${S}/.defaultenv ';'
 	echo "CONFIG_DEFAULT_ENVIRONMENT_PATH=\"${S}/.defaultenv\"" > ${B}/.defaultenv.cfg
 
+	# If ${BAREBOX_FIRMWARE_DIR} is set, use that for CONFIG_EXTRA_FIRMWARE_DIR
+	touch ${B}/.firmware.cfg
+	if [ -n "${BAREBOX_FIRMWARE_DIR}" ]; then
+		echo "CONFIG_EXTRA_FIRMWARE_DIR=\"${BAREBOX_FIRMWARE_DIR}\"" > ${B}/.firmware.cfg
+	fi
+
 	${S}/scripts/kconfig/merge_config.sh -m ${B}/.config \
 		${B}/.defaultenv.cfg \
+		${B}/.firmware.cfg \
 		${@" ".join(find_cfgs(d))}
 
 	cml1_do_configure
 }
 
-BAREBOX_FIRMWARE_DIR ?= ""
-BAREBOX_FIRMWARE_DIR[doc] = "Overwrite barebox' firmware blobs search directory (CONFIG_EXTRA_FIRMWARE_DIR) with this path"
-
 do_compile () {
-	# If ${BAREBOX_FIRMWARE_DIR} is set, use that for CONFIG_EXTRA_FIRMWARE_DIR
-	if [ -n "${BAREBOX_FIRMWARE_DIR}" ]; then
-		sed -i -e "s,^\(CONFIG_EXTRA_FIRMWARE_DIR=\"\).*\"$,\1${BAREBOX_FIRMWARE_DIR}\"," \
-				${B}/.config
-	fi
-
 	# Barebox uses pkg-config only for building native tools
 	export PKG_CONFIG_LIBDIR="${STAGING_DIR_NATIVE}${libdir}/pkgconfig:${STAGING_DIR_NATIVE}/usr/share/pkgconfig"
 	export PKG_CONFIG_SYSROOT_DIR=

--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -49,12 +49,10 @@ EXTRA_OEMAKE = " \
 do_configure() {
 	if [ -e ${WORKDIR}/defconfig ]; then
 		cp ${WORKDIR}/defconfig ${B}/.config
+	elif [ -n "${BAREBOX_CONFIG}" ]; then
+		oe_runmake ${BAREBOX_CONFIG}
 	else
-		if [ -n "${BAREBOX_CONFIG}" ]; then
-			oe_runmake ${BAREBOX_CONFIG}
-		else
-			bbfatal "No defconfig given. Either add file 'file://defconfig' to SRC_URI or set BAREBOX_CONFIG"
-		fi
+		bbfatal "No defconfig given. Either add file 'file://defconfig' to SRC_URI or set BAREBOX_CONFIG"
 	fi
 
 	${S}/scripts/kconfig/merge_config.sh -m .config ${@" ".join(find_cfgs(d))}


### PR DESCRIPTION
This change allows to merge multiple env* directories to compose the default environment. That's particularly useful to split the barebox configuration into multiple directories added via OVERRIDES, like distro or machine specific scripts.

At the same time, move config related changes into the configure step and simplify it a bit.