### PR TITLE
barebox: add dependency on pkgconfig-native

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -10,6 +10,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 inherit kernel-arch deploy
 inherit cml1
+inherit pkgconfig
 
 DEPENDS = "libusb1-native lzop-native bison-native flex-native"
 


### PR DESCRIPTION
As ``pkgconfig`` is potentially nedded to build some of barebox' host tools (e.g. [``mxsimage``](https://git.pengutronix.de/cgit/barebox/tree/scripts/Makefile?h=v2021.11.0#n32) or [``imx-usb-loader``](https://git.pengutronix.de/cgit/barebox/tree/scripts/imx/Makefile?h=v2021.11.0#n4)) starting with [this](https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=04b37f914ed1) Yocto commit we have to explicitely depend on it, otherwise the information that should have been gathered via ``pkg-config [...]`` is missing with the result that building those tools breaks.