### PR TITLE
classes/bootspec: do not obtain kernel version from do_shared_workdir

### DIFF
--- a/classes/bootspec.bbclass
+++ b/classes/bootspec.bbclass
@@ -1,10 +1,5 @@
 # Adds boot spec entry for first FSTYPE found
 
-# require STAGING_KERNEL_BUILDDIR to be populated properly
-do_rootfs[depends] += "virtual/kernel:do_shared_workdir"
-inherit linux-kernel-base
-KERNEL_VERSION = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"
-
 BOOTSPEC_TITLE ?= "${SUMMARY}"
 BOOTSPEC_TITLE[doc] = "Content of the boot spec entry 'title' line"
 
@@ -14,7 +9,7 @@ BOOTSPEC_OPTIONS_squashfs = "rootfstype=squashfs"
 BOOTSPEC_OPTIONS_squashfs-lzo = "rootfstype=squashfs"
 BOOTSPEC_OPTIONS_squashfs-xz = "rootfstype=squashfs"
 
-BOOTSPEC_VERSION ?= "${KERNEL_VERSION}"
+BOOTSPEC_VERSION ?= "${PV}"
 BOOTSPEC_VERSION[doc] ?= "Content of the bootspec version entry"
 
 BOOTSPEC_OPTIONS_DEFAULT = ""
@@ -63,7 +58,7 @@ python create_bootspec() {
         bootspecfile.write('version    %s\n' % d.getVar('BOOTSPEC_VERSION'))
         bootspecfile.write('options    %s\n' % d.expand('${BOOTSPEC_OPTIONS}'))
         bootspecfile.write(d.getVar('BOOTSPEC_EXTRALINE').replace(r'\n', '\n'))
-        bootspecfile.write('linux      %s\n' % d.expand('/boot/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}'))
+        bootspecfile.write('linux      %s\n' % d.expand('/boot/${KERNEL_IMAGETYPE}'))
         if x != "default":
             # Prefer BSP dts if BSP and kernel provide the same dts
             dtbpath = '/boot/devicetree/' if x in ext_dtbs else '/boot/'


### PR DESCRIPTION
The idea to obtain the exact kernel version looked simple:

* Depend on do_shared_workdir task of kernel to have its source dir
  populated
* run get_kernelversion_file() method to obtain the exact version string

This is fine as it allows to set the 'version' field and let the 'linux'
field point to the exact kernel version file.

However, reality hits you when attempting to build an eSDK.

In an eSDK, we have a set of fixed signatures and shared state artifacts
for each of them. However, do_shared_workdir is different as it is a
setscene-whitelisted task that always gets executed in dry run mode to
trigger depending tasks.
This means, despite it has a sort of setscene task, this task has no
data associated.

Now when using the bootspec class in an image that we build an eSDK
from, we make do_shared_workdir an actual build dependency for the
do_rootfs task. This will result in bitbake trying to find and unpack an
sstate artifacts for it, which must fail.
In consequence, bitbake attempts to execute all the tasks upstream.
But, as we are in an eSDK build incapable of executing actual tasks, this
ends in an error message like:

> ERROR: Task linux-yocto.do_fetch attempted to execute unexpectedly

By not knowing any good alternative to obtain the exact kernel version,
this patch now simply removes the kernel version magic and thus the
dependency on do_shared_workdir.

For the 'version' field we default to `${PN}` instead and the 'linux'
field now simply points to the `/boot/${KERNEL_IMAGETYPE}` symlink that
should exist on all systems.

In this form it does not allow differentiating multiple kernel in the
same directory, but this was never a real core skill of this class,
anyway.
The main purpose is still to have multiple supported dtbs in the same
rootfs.