### PR TITLE
Change LICENSE Entries to SPDX Identifiers

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.barebox.org/"
 SECTION = "bootloaders"
 PROVIDES = "virtual/bootloader"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f5125d13e000b9ca1f0d3364286c4192"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-core/dt-utils/dt-utils.inc
+++ b/recipes-core/dt-utils/dt-utils.inc
@@ -1,7 +1,7 @@
 DESCRIPTION = "device-tree and barebox-related tools"
 HOMEPAGE = "http://git.pengutronix.de/?p=tools/dt-utils.git"
 SECTION = "base"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9ac2e7cff1ddaf48b6eab6028f23ef88"
 DEPENDS = "udev"
 PR = "r0"

--- a/recipes-devtools/genext2fs/genext2fs.inc
+++ b/recipes-devtools/genext2fs/genext2fs.inc
@@ -4,7 +4,7 @@ as a normal (non-root) user."
 HOMEPAGE = "http://genext2fs.sourceforge.net/"
 SECTION = "console/utils"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f \
                     file://genext2fs.c;beginline=9;endline=17;md5=23ea077d1f7fbfd3a6fa573b415fa001"
 

--- a/recipes-devtools/genimage/genimage.inc
+++ b/recipes-devtools/genimage/genimage.inc
@@ -2,7 +2,7 @@ SUMMARY = "Image generation tool"
 HOMEPAGE = "https://github.com/pengutronix/genimage"
 
 SECTION = "base"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://genimage.c;beginline=1;endline=15;md5=bd66ae8b32d8a336e09c1d4a9924a49f"
 
 DEPENDS = "confuse dosfstools"

--- a/recipes-devtools/memtool/memtool_2018.03.0.bb
+++ b/recipes-devtools/memtool/memtool_2018.03.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "A handy tool to manipulate and read memory mapped registers"
 HOMEPAGE = "https://github.com/pengutronix/memtool"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "http://www.pengutronix.de/software/memtool/downloads/memtool-${PV}.tar.xz"


### PR DESCRIPTION
OE-Core started in [9379f80f484f](https://git.openembedded.org/openembedded-core/commit/?id=9379f80f484f) to warn when it finds obsolete license identifiers as it was decided to standardize on SPDX license names. Use the conversion script introduced in OE-Core's commit [512cd4ca91bc](https://git.openembedded.org/openembedded-core/commit/?id=512cd4ca91bc) to silence the warnings.