### PR TITLE
classes: genimage: improve parametrized image generation

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -3,7 +3,8 @@
 # Class to generate disk images using the `genimage` tool.
 #
 # In order to build an image, your recipe must inherit the genimage class and
-# have a valid genimage configuration file in SRC_URI, named `genimage.config`.
+# have a valid genimage configuration file in SRC_URI, named `genimage.config`
+# by default.
 #
 #   inherit genimage
 #
@@ -58,6 +59,7 @@
 #
 # Most common variables for customization from image recipe:
 #
+# GENIMAGE_CONFIG	- config passed to genimage --config (default: 'genimage.config')
 # GENIMAGE_IMAGE_SUFFIX	- file extension suffix for created image (default: 'img')
 # GENIMAGE_ROOTFS_IMAGE - input rootfs image to generate file system images from
 # GENIMAGE_ROOTFS_IMAGE_FSTYPE	- input roofs FSTYPE to use (default: 'tar.bz2')
@@ -76,6 +78,8 @@ B = "${WORKDIR}/genimage-${PN}"
 INHIBIT_DEFAULT_DEPS = "1"
 
 DEPENDS += "genimage-native"
+
+GENIMAGE_CONFIG ?= "genimage.config"
 
 GENIMAGE_IMAGE_SUFFIX ?= "img"
 
@@ -102,15 +106,15 @@ GENIMAGE_OPTS ??= ""
 do_genimage[cleandirs] = "${GENIMAGE_TMPDIR} ${GENIMAGE_ROOTDIR} ${B}"
 
 do_configure () {
-    if ! grep -q "@IMAGE@" ${WORKDIR}/genimage.config; then
-        bbnote "genimage.config does not contain @IMAGE@ marker"
+    if ! grep -q "@IMAGE@" ${WORKDIR}/${GENIMAGE_CONFIG}; then
+        bbnote "${GENIMAGE_CONFIG} does not contain @IMAGE@ marker"
     fi
 }
 
 do_genimage[dirs] = "${B}"
 
 fakeroot do_genimage () {
-    sed s:@IMAGE@:${GENIMAGE_IMAGE_FULLNAME}:g ${WORKDIR}/genimage.config > ${B}/.config
+    sed s:@IMAGE@:${GENIMAGE_IMAGE_FULLNAME}:g ${WORKDIR}/${GENIMAGE_CONFIG} > ${B}/.config
 
     # unpack input rootfs image if given
     if [ "x${GENIMAGE_ROOTFS_IMAGE}" != "x" ]; then

--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -145,13 +145,13 @@ addtask genimage after do_configure before do_build
 do_deploy () {
     install ${B}/* ${DEPLOYDIR}/
 
-    if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_FULLNAME} ]; then
-        ln -sf ${GENIMAGE_IMAGE_FULLNAME} ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_FULLNAME}
-    fi
-    if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_FULLNAME}.bmap ] ; then
-        ln -sf ${GENIMAGE_IMAGE_FULLNAME}.bmap ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_FULLNAME}.bmap
-    fi
-
+    for img in ${B}/*; do
+        img=$(basename "${img}")
+        case "$img" in *"${GENIMAGE_IMAGE_FULLNAME}"*)
+            ln -sf ${img} \
+                ${DEPLOYDIR}/$(echo "${img}" | sed "s/${GENIMAGE_IMAGE_FULLNAME}/${GENIMAGE_IMAGE_LINK_FULLNAME}/")
+        esac
+    done
 }
 
 addtask deploy after do_genimage before do_build

--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -1,4 +1,4 @@
-# genimage.bbclas
+# genimage.bbclass
 #
 # Class to generate disk images using the `genimage` tool.
 #


### PR DESCRIPTION
I need to generate multiple images and added below features to avoid duplication in the genimage.bbclass.

* `GENIMAGE_CONFIG`: Allow multiple configs to exist in the same directory and select between them by name
* symlink creation: Otherwise need duplicated do_deploy_append in recipes
* `@VARIABLES@` expansion: So same config can be reused with slight changes. I used to do this with sed, but now that `.config` is created in `do_genimage` and removed after, this requires `genimage.bbclass` changes.