### PR TITLE
barebox: remove dependency on lzop-native

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -12,7 +12,7 @@ inherit kernel-arch deploy
 inherit cml1
 inherit pkgconfig
 
-DEPENDS = "libusb1-native lzop-native bison-native flex-native"
+DEPENDS = "libusb1-native bison-native flex-native"
 
 PACKAGES += "${PN}-bareboxenv ${PN}-bareboxcrc32 ${PN}-kernel-install \
          ${PN}-bareboximd"


### PR DESCRIPTION
In poky commit [4f4a5dc9](https://git.yoctoproject.org/poky/commit/?id=4f4a5dc9566171f0bee7c644c38335cba8b24a82) ("lzop: remove recipe from oe-core") lzop recipe and all dependencies on it were removed from oe-core because lzop is seen as deprecated and hasn't seen any release since 2017.

Thus remove dependency on it from barebox build, too.
This will potentially break use cases where lzop is still used for compression. Consider switching to different compression method then.