### PR TITLE
barebox: disable ARMv8.3+ pointer authentication

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -42,10 +42,11 @@ def get_layer_rev(path):
 
 BAREBOX_BUILDSYSTEM_VERSION ??= "${@get_layer_rev(os.path.dirname(d.getVar('FILE')))}"
 
-EXTRA_OEMAKE = " \
+EXTRA_OEMAKE = ' \
   CROSS_COMPILE=${TARGET_PREFIX} -C ${S} O=${B} \
   BUILDSYSTEM_VERSION=${BAREBOX_BUILDSYSTEM_VERSION} \
-"
+  CC="${TARGET_PREFIX}gcc ${TOOLCHAIN_OPTIONS} -mbranch-protection=none" \
+'
 
 do_configure() {
 	if [ -e ${WORKDIR}/defconfig ]; then


### PR DESCRIPTION
Pointer authentication breaks the barebox ARM64 header leading to issues
like failure to use imx-usb-loader with barebox running on an i.MX8MM.

There's a patch to disable pointer authentication on the barebox side[1],
but that will only be available in barebox v2022.11.0 at the earliest.
Building older barebox versions for ARM64 with Honister toolchains
or later will continue to generate barebox images with the broken header.

Fix this by setting `-mbranch-protection=none` in the recipe as well.
barebox doesn't currently stand to benefit from pointer authentication
anyway: SoCs supporting it are scarce (Apple M1/2 basically) and pointer
authentication needs support in barebox itself, which is not existent.

[1]: https://lore.barebox.org/barebox/20221019135322.2283270-1-a.fatoum@pengutronix.de/T/#u