### PR TITLE
distro: ptx: default to ipk package management

### DIFF
--- a/conf/distro/ptx.conf
+++ b/conf/distro/ptx.conf
@@ -43,3 +43,6 @@ INHERIT += "uninative"
 
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"
+
+# recommend ipk package management - make sure to comment or set it in local.conf.sample
+PACKAGE_CLASSES ?= "package_ipk"


### PR DESCRIPTION
ipk package management is more light-weight than rpm and sufficient for most use cases. It requires less crude work arounds like package version translations due to character restrictions on Yocto's side.

This should be taken as a recommendation, since projects are encouraged to create their own distro (maybe copied from here) and PACKAGE_CLASSES is set in local.conf(.sample) by default.