### PR TITLE
Add platsch Recipe

### DIFF
--- a/.github/workflows/meta-ptx.yml
+++ b/.github/workflows/meta-ptx.yml
@@ -50,3 +50,7 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake microcom
+      - name: Build platsch
+        run: |
+          source poky/oe-init-build-env build
+          bitbake platsch

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_ptx = "6"
 
 LAYERDEPENDS_ptx = "core"
 
-LAYERSERIES_COMPAT_ptx = "kirkstone langdale"
+LAYERSERIES_COMPAT_ptx = "langdale"

--- a/recipes-graphics/platsch/platsch_git.bb
+++ b/recipes-graphics/platsch/platsch_git.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "Simple splash screen application"
+HOMEPAGE = "https://git.pengutronix.de/cgit/platsch"
+LICENSE = "0BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1a4c8b8d288b4fc32c3c4830d7a5e169"
+
+SRC_URI = "git://git.pengutronix.de/git/platsch;protocol=https;branch=master"
+PV = "0.1+git${SRCPV}"
+SRCREV = "9ba41fd75c7b0b5ba47549ed3fabe6d95c75987d"
+S = "${WORKDIR}/git"
+
+DEPENDS = "libdrm"
+
+inherit pkgconfig autotools


### PR DESCRIPTION
platsch is a simple splash screen application meant to be run as pid 1.

Since platsch depends on libdrm >= 2.4.112 which is only available in langdale and newer, drop the layer's kirkstone compatibility.