### PR TITLE
genimage.bbclass: set LICENSE with '?=' to avoid forcing MIT license.

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -67,7 +67,7 @@
 
 inherit image-artifact-names deploy
 
-LICENSE = "MIT"
+LICENSE ?= "MIT"
 PACKAGES = ""
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
While genimage itself is MIT-licensed, images created with `genimage` using the `inherit genimage` should not be forced to be MIT-licensed. The standard for `.bbclass` files which set `LICENSE` is to set it with `?=` so the recipe can override it. Otherwise (with `=`) it isn't possible for the recipe to override it.

This commit is cherry-picked onto `master` from PR #115 as requested by @ejoerns.