### PR TITLE
layer.conf: add 'nanbield' to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_ptx = "6"
 
 LAYERDEPENDS_ptx = "core"
 
-LAYERSERIES_COMPAT_ptx = "langdale mickledore"
+LAYERSERIES_COMPAT_ptx = "mickledore nanbield"


### PR DESCRIPTION
poky/oe-core just released 'nanbield' and thus removed 'mickledore' compatibility.

While at it, remove 'langdale' which is out of support.