### PR TITLE
dt-utils: update to 2023.11.0

### DIFF
--- a/recipes-core/dt-utils/dt-utils.inc
+++ b/recipes-core/dt-utils/dt-utils.inc
@@ -2,7 +2,7 @@ DESCRIPTION = "device-tree and barebox-related tools"
 HOMEPAGE = "http://git.pengutronix.de/?p=tools/dt-utils.git"
 SECTION = "base"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://COPYING;md5=9ac2e7cff1ddaf48b6eab6028f23ef88"
+LIC_FILES_CHKSUM = "file://COPYING;md5=18d902a0242c37a4604224b47d02f802"
 DEPENDS = "udev"
 PR = "r0"
 

--- a/recipes-core/dt-utils/dt-utils_2021.03.0.bb
+++ b/recipes-core/dt-utils/dt-utils_2021.03.0.bb
@@ -1,4 +1,0 @@
-require dt-utils.inc
-
-SRC_URI[md5sum] = "acf0b5e3b18e40e6172b67fbad2e52fb"
-SRC_URI[sha256sum] = "36a56924e356250988315cd8761fde52832e6d4934323aca2827ff93fa12907f"

--- a/recipes-core/dt-utils/dt-utils_2023.11.0.bb
+++ b/recipes-core/dt-utils/dt-utils_2023.11.0.bb
@@ -1,0 +1,4 @@
+require dt-utils.inc
+
+SRC_URI[md5sum] = "4aa4ef310c76a2baa5df62254f0b7453"
+SRC_URI[sha256sum] = "d224d941c076c143f43d59cd7c6e1c522926064a31ac34a67720632ddecb6b53"


### PR DESCRIPTION
This update is based on the equivalent updates in [`meta-rauc`](https://github.com/rauc/meta-rauc):

-  rauc/meta-rauc#284 (2021.03.0 -> 2023.08.0)
-  rauc/meta-rauc#292 (2023.08.0 -> 2023.11.0).
