### PR TITLE
conf: layer: add 'scarthgap' to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_ptx = "6"
 
 LAYERDEPENDS_ptx = "core"
 
-LAYERSERIES_COMPAT_ptx = "mickledore nanbield"
+LAYERSERIES_COMPAT_ptx = "nanbield scarthgap"


### PR DESCRIPTION
OE-Core updated compatibility in upstream commit [`0e42326dfd6b ("layer.conf: Prepare for release, drop nanbield LAYERSERIES")`](https://github.com/openembedded/openembedded-core/commit/0e42326dfd6b9042b405329ceb56a93199a89a85) to upcoming Release 5.0 ("`scarthgap`").

Update layer compatibility to match OE-Core, and drop "`mickledore`" as according to [_Yocto Project Releases_](https://wiki.yoctoproject.org/wiki/Releases) it is indicated as EOL.
