### PR TITLE
genimage: added missing 'mtools' dependency.

### DIFF
--- a/recipes-devtools/genimage/genimage.inc
+++ b/recipes-devtools/genimage/genimage.inc
@@ -5,7 +5,7 @@ SECTION = "base"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://genimage.c;beginline=1;endline=15;md5=bd66ae8b32d8a336e09c1d4a9924a49f"
 
-DEPENDS = "confuse dosfstools"
+DEPENDS = "confuse dosfstools mtools"
 
 SRC_URI = "http://www.pengutronix.de/software/genimage/download/genimage-${PV}.tar.xz"
 


### PR DESCRIPTION
Ran into an issue where mcopy was missing. 
This should make sure mtools is on the host machine before building genimage. 