### PR TITLE
barebox: readd lzop-native

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -12,7 +12,7 @@ inherit kernel-arch deploy
 inherit cml1
 inherit pkgconfig
 
-DEPENDS = "libusb1-native bison-native flex-native"
+DEPENDS = "libusb1-native lzop-native bison-native flex-native"
 
 PACKAGES += "${PN}-bareboxenv ${PN}-bareboxcrc32 ${PN}-kernel-install \
          ${PN}-bareboximd"


### PR DESCRIPTION
In scarthgap, lzop has been readded to poky with commit 07006c486722 ("Revert "lzop: remove recipe from oe-core""), readd it to the barebox depends to reallow lzop compression.

This reverts commit 38ada68c708d793eae99ace05dae1ba061fbfbdc.