### PR TITLE
follow WORKDIR -> UNPACKDIR transition 

### DIFF
--- a/classes-recipe/genimage.bbclass
+++ b/classes-recipe/genimage.bbclass
@@ -82,7 +82,8 @@ PACKAGES = ""
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 B = "${WORKDIR}/genimage-${PN}"
 
@@ -133,7 +134,7 @@ GENIMAGE_OPTS ??= ""
 do_genimage_preprocess[cleandirs] = "${GENIMAGE_TMPDIR} ${GENIMAGE_ROOTDIR} ${B}"
 
 do_configure () {
-    if ! grep -q "@IMAGE@" ${WORKDIR}/${GENIMAGE_CONFIG}; then
+    if ! grep -q "@IMAGE@" ${S}/${GENIMAGE_CONFIG}; then
         bbnote "${GENIMAGE_CONFIG} does not contain @IMAGE@ marker"
     fi
 }
@@ -149,7 +150,7 @@ python do_genimage_preprocess () {
 
     import re
 
-    infile = d.getVar('WORKDIR') + "/" + d.getVar('GENIMAGE_CONFIG')
+    infile = d.getVar('S') + "/" + d.getVar('GENIMAGE_CONFIG')
     outfile = d.getVar('B') + "/.config"
 
     with open(infile, "r+") as input:
@@ -170,7 +171,7 @@ fakeroot do_genimage () {
         --config ${B}/.config \
         --tmppath ${GENIMAGE_TMPDIR} \
         --inputpath ${DEPLOY_DIR_IMAGE} \
-        --includepath ${WORKDIR} \
+        --includepath ${S} \
         --outputpath ${B} \
         --rootpath ${GENIMAGE_ROOTDIR} \
         ${GENIMAGE_OPTS}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_ptx = "6"
 
 LAYERDEPENDS_ptx = "core"
 
-LAYERSERIES_COMPAT_ptx = "scarthgap"
+LAYERSERIES_COMPAT_ptx = "styhead"

--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -48,8 +48,8 @@ EXTRA_OEMAKE = " \
 "
 
 do_configure() {
-	if [ -e ${WORKDIR}/defconfig ]; then
-		cp ${WORKDIR}/defconfig ${B}/.config
+	if [ -e ${UNPACKDIR}/defconfig ]; then
+		cp ${UNPACKDIR}/defconfig ${B}/.config
 	else
 		if [ -n "${BAREBOX_CONFIG}" ]; then
 			oe_runmake ${BAREBOX_CONFIG}
@@ -68,9 +68,9 @@ BAREBOX_FIRMWARE_DIR[doc] = "Overwrite barebox' firmware blobs search directory 
 do_compile () {
 	# If there is an 'env' directory, append its content
 	# to the compiled environment
-	if [ -d ${WORKDIR}/env/ ]; then \
+	if [ -d ${UNPACKDIR}/env/ ]; then \
 		mkdir -p ${S}/.yocto-defaultenv
-		cp -r ${WORKDIR}/env/* ${S}/.yocto-defaultenv/; \
+		cp -r ${UNPACKDIR}/env/* ${S}/.yocto-defaultenv/; \
 		grep -q .yocto-defaultenv ${B}/.config || \
 	        sed -i -e "s,^\(CONFIG_DEFAULT_ENVIRONMENT_PATH=.*\)\"$,\1 .yocto-defaultenv\"," \
 		                ${B}/.config; \

--- a/recipes-core/ptx-profile/ptx-profile.bb
+++ b/recipes-core/ptx-profile/ptx-profile.bb
@@ -4,7 +4,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "file://00-ptx.sh"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 do_install () {
 	install -d ${D}${sysconfdir}/profile.d/

--- a/recipes-core/systemd/systemd-rc-once.bb
+++ b/recipes-core/systemd/systemd-rc-once.bb
@@ -9,16 +9,17 @@ SRC_URI = "\
   file://systemd-rc-once \
   "
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 inherit allarch systemd
 
 do_install() {
 	install -d ${D}${base_libdir}/init
-	install -m 0755 ${WORKDIR}/rc-once.sh ${D}${base_libdir}/init/
+	install -m 0755 ${S}/rc-once.sh ${D}${base_libdir}/init/
 	install -d ${D}${systemd_unitdir}/system
-	install -m 0755 ${WORKDIR}/systemd-rc-once ${D}${systemd_unitdir}/
-	install -m 0644 ${WORKDIR}/rc-once.service ${D}${systemd_unitdir}/system/
+	install -m 0755 ${S}/systemd-rc-once ${D}${systemd_unitdir}/
+	install -m 0644 ${S}/rc-once.service ${D}${systemd_unitdir}/system/
 	install -d ${D}${systemd_unitdir}/system/system-update.target.wants
 	ln -sf ../rc-once.service ${D}${systemd_unitdir}/system/system-update.target.wants/rc-once.service
 	install -d ${D}${sysconfdir}/rc.once.d


### PR DESCRIPTION
This adapts to the oe-core rework to enforce a separate directory for unpacking local sources (`UNPACKDIR`) instead of polluting `WORKDIR` directly.

Follows the preliminary guidelines from:
https://lists.openembedded.org/g/openembedded-architecture/message/2007

Removes compatibility with `scarthgap` and adds `styhead` instead.