### PR TITLE
genimage.bbclass: disable SSTATE artifact generation and avoid unnecessary rebuilds

### DIFF
--- a/classes-recipe/genimage.bbclass
+++ b/classes-recipe/genimage.bbclass
@@ -187,7 +187,7 @@ fakeroot do_genimage () {
 do_genimage[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 do_genimage[prefuncs] += "do_genimage_preprocess"
 
-addtask genimage after do_configure before do_build
+addtask genimage after do_configure
 
 do_deploy () {
     install -m 0644 ${B}/* ${DEPLOYDIR}/

--- a/classes-recipe/genimage.bbclass
+++ b/classes-recipe/genimage.bbclass
@@ -186,6 +186,7 @@ fakeroot do_genimage () {
 }
 do_genimage[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 do_genimage[prefuncs] += "do_genimage_preprocess"
+SSTATE_SKIP_CREATION:task-genimage = '1'
 
 addtask genimage after do_configure
 


### PR DESCRIPTION
These changes will notably impact how the `genimage.bbclass` performs.

They will

* save disk space (by removing sstate artifacts) 
* better trigger rebuilds where useful
* avoid unnecessary rebuilds

Fixes #130 