### PR TITLE
bootspec.bbclass: Refactoring, Fixes and Documentation

### DIFF
--- a/classes-recipe/bootspec.bbclass
+++ b/classes-recipe/bootspec.bbclass
@@ -1,4 +1,18 @@
-# Adds boot spec entry for first FSTYPE found
+# Class for adding a basic bootloader specification file to rootfs images
+#
+# For more information, see:
+# https://uapi-group.org/specifications/specs/boot_loader_specification/
+#
+# To use the class in your image recipe, simply add
+#
+#   inherit bootspec
+#
+# This will create a bootspec entry for each devicetree found in
+# KERNEL_DEVICETREE and EXTERNAL_KERNEL_DEVICETREE.
+# For machines not using devicetree, it will create a single default.conf.
+#
+# The bootspec lines generated can be customized with the BOOTSPEC_TITLE,
+# BOOTSPEC_VERSION, BOOTSPEC_OPTIONS and BOOTSPEC_EXTRALINE variables.
 
 BOOTSPEC_TITLE ?= "${SUMMARY}"
 BOOTSPEC_TITLE[doc] = "Content of the boot spec entry 'title' line"

--- a/classes-recipe/bootspec.bbclass
+++ b/classes-recipe/bootspec.bbclass
@@ -34,6 +34,8 @@ BOOTSPEC_OPTIONS[doc] = "Content of the boot spec entry 'options' line"
 BOOTSPEC_EXTRALINE ?= ""
 BOOTSPEC_EXTRALINE[doc] = "Allows to add extra content to bootspec entries, lines must be terminated with a newline"
 
+do_rootfs[vardeps] += "BOOTSPEC_TITLE BOOTSPEC_VERSION BOOTSPEC_OPTIONS BOOTSPEC_EXTRALINE"
+
 python create_bootspec() {
     dtbs = (d.getVar('KERNEL_DEVICETREE') or '').split()
     ext_dtbs = os.listdir(d.getVar('EXTERNAL_KERNEL_DEVICETREE')) if d.getVar('EXTERNAL_KERNEL_DEVICETREE') else []

--- a/classes-recipe/bootspec.bbclass
+++ b/classes-recipe/bootspec.bbclass
@@ -56,7 +56,7 @@ python create_bootspec() {
 
         bootspecfile.write('title      %s\n' % d.getVar('BOOTSPEC_TITLE'))
         bootspecfile.write('version    %s\n' % d.getVar('BOOTSPEC_VERSION'))
-        bootspecfile.write('options    %s\n' % d.expand('${BOOTSPEC_OPTIONS}'))
+        bootspecfile.write('options    %s\n' % d.getVar('BOOTSPEC_OPTIONS'))
         bootspecfile.write(d.getVar('BOOTSPEC_EXTRALINE').replace(r'\n', '\n'))
         bootspecfile.write('linux      %s\n' % d.expand('/boot/${KERNEL_IMAGETYPE}'))
         if x != "default":

--- a/classes-recipe/bootspec.bbclass
+++ b/classes-recipe/bootspec.bbclass
@@ -26,21 +26,20 @@ BOOTSPEC_OPTIONS_squashfs-xz = "rootfstype=squashfs"
 BOOTSPEC_VERSION ?= "${PV}"
 BOOTSPEC_VERSION[doc] ?= "Content of the bootspec version entry"
 
-BOOTSPEC_OPTIONS_DEFAULT = ""
-
-python () {
+# Search in IMAGE_FSTYPES for a type we have a default for
+def bootspec_default_option(d):
     for type in (d.getVar('IMAGE_FSTYPES') or "").split():
         option = d.getVar('BOOTSPEC_OPTIONS_%s' % type)
         if option:
-            d.setVar('BOOTSPEC_OPTIONS_DEFAULT', option)
-            break;
+            return option
 
+python () {
     if d.getVar('PREFERRED_PROVIDER_virtual/dtb'):
         d.appendVarFlag('do_rootfs', 'depends', ' virtual/dtb:do_populate_sysroot')
         d.setVar('EXTERNAL_KERNEL_DEVICETREE', '${RECIPE_SYSROOT}/boot/devicetree')
 }
 
-BOOTSPEC_OPTIONS ?= "${BOOTSPEC_OPTIONS_DEFAULT}"
+BOOTSPEC_OPTIONS ?= "${@bootspec_default_option(d)}"
 BOOTSPEC_OPTIONS[doc] = "Content of the boot spec entry 'options' line"
 
 BOOTSPEC_EXTRALINE ?= ""

--- a/classes-recipe/bootspec.bbclass
+++ b/classes-recipe/bootspec.bbclass
@@ -15,8 +15,6 @@ BOOTSPEC_VERSION[doc] ?= "Content of the bootspec version entry"
 BOOTSPEC_OPTIONS_DEFAULT = ""
 
 python () {
-    option = ""
-
     for type in (d.getVar('IMAGE_FSTYPES') or "").split():
         option = d.getVar('BOOTSPEC_OPTIONS_%s' % type)
         if option:


### PR DESCRIPTION
* Add documentation to the header
* use `[vardeps]` to fix rebuilds when changing `BOOTSPEC_` options
* refactor code for `BOOTSPEC_OPTIONS` default
* minor cleanups