### PR TITLE
genimage: update SUMMARY and LIC_FILES_CHKSUM

### DIFF
--- a/recipes-devtools/genimage/genimage.inc
+++ b/recipes-devtools/genimage/genimage.inc
@@ -1,9 +1,9 @@
-SUMMARY = "Image generation tool"
+SUMMARY = "The image creation tool"
 HOMEPAGE = "https://github.com/pengutronix/genimage"
 
 SECTION = "base"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://genimage.c;beginline=1;endline=15;md5=bd66ae8b32d8a336e09c1d4a9924a49f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS = "confuse dosfstools"
 


### PR DESCRIPTION
Sync the summary with the title in the project's README. Genimage got a dedicated `COPYING` file in 2016. Use it now.