### PR TITLE
genimage: remove build dependency on dosfstools

### DIFF
--- a/recipes-devtools/genimage/genimage.inc
+++ b/recipes-devtools/genimage/genimage.inc
@@ -5,7 +5,7 @@ SECTION = "base"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-DEPENDS = "confuse dosfstools"
+DEPENDS = "confuse"
 
 SRC_URI = "http://www.pengutronix.de/software/genimage/download/genimage-${PV}.tar.xz"
 


### PR DESCRIPTION
It has never been a build dependency.