### PR TITLE
confuse: re-add search path patch dropped with the v3.3 update

### DIFF
--- a/recipes-devtools/confuse/confuse_3.3.bb
+++ b/recipes-devtools/confuse/confuse_3.3.bb
@@ -8,6 +8,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=42fa47330d4051cd219f7d99d023de3a"
 SRC_URI = "https://github.com/libconfuse/libconfuse/releases/download/v${PV}/confuse-${PV}.tar.gz"
 SRC_URI[sha256sum] = "3a59ded20bc652eaa8e6261ab46f7e483bc13dad79263c15af42ecbb329707b8"
 
+SRC_URI += "file://0001-only-apply-search-path-logic-to-relative-pathnames.patch"
+
 EXTRA_OECONF = "--enable-shared"
 
 inherit autotools gettext binconfig pkgconfig lib_package

--- a/recipes-devtools/confuse/files/0001-only-apply-search-path-logic-to-relative-pathnames.patch
+++ b/recipes-devtools/confuse/files/0001-only-apply-search-path-logic-to-relative-pathnames.patch
@@ -1,0 +1,48 @@
+From b684f4cc25821b6e86a58576f864e4b12dfdfecc Mon Sep 17 00:00:00 2001
+From: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
+Date: Sat, 5 Jun 2021 22:57:51 +0200
+Subject: [PATCH] only apply search path logic to relative pathnames
+
+Adding any directory to the search path via cfg_add_searchpath breaks
+lookup of absolute paths. So change the logic in cfg_searchpath() to
+ignore the search path when the given filename is absolute, and merely
+check that for existence.
+
+This is technically an ABI change, but the current behaviour is quite
+unusual and unexpected.
+
+Upstream-Status: Backport [https://github.com/libconfuse/libconfuse/pull/155]
+
+Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
+---
+ src/confuse.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/confuse.c b/src/confuse.c
+index 2ea0254..19b56e3 100644
+--- a/src/confuse.c
++++ b/src/confuse.c
+@@ -1746,12 +1746,20 @@ DLLIMPORT char *cfg_searchpath(cfg_searchpath_t *p, const char *file)
+ 		return NULL;
+ 	}
+ 
++	if (file[0] == '/') {
++		fullpath = strdup(file);
++		if (!fullpath)
++			return NULL;
++		goto check;
++	}
++
+ 	if ((fullpath = cfg_searchpath(p->next, file)) != NULL)
+ 		return fullpath;
+ 
+ 	if ((fullpath = cfg_make_fullpath(p->dir, file)) == NULL)
+ 		return NULL;
+ 
++check:
+ #ifdef HAVE_SYS_STAT_H
+ 	err = stat((const char *)fullpath, &st);
+ 	if ((!err) && S_ISREG(st.st_mode))
+-- 
+2.31.1
+


### PR DESCRIPTION
Contrary to my claim in meta-ptx commit 52d88c6c ("confuse: update to 3.3"), the patch was not part of v3.3, yet (but is part of master).

Thus re-add it and fix the Upstream-Status by replacing the now invalid 'Accepted' with 'Backport'.

Fixes #143 