### PR TITLE
barebox: default assign BAREBOX_IMAGE_SUFFIX

### DIFF
--- a/recipes-bsp/barebox/barebox.inc
+++ b/recipes-bsp/barebox/barebox.inc
@@ -118,7 +118,7 @@ do_install() {
 }
 
 # Suffix that allows to create different barebox images in one BSP
-BAREBOX_IMAGE_SUFFIX = ""
+BAREBOX_IMAGE_SUFFIX ?= ""
 # This allows a machine.conf to specify the required images to install instead
 # of installing all found images
 BAREBOX_IMAGES ??= "*.img"


### PR DESCRIPTION
Default assign the BAREBOX_IMAGE_SUFFIX so it is easily overridable within a recipe.