### PR TITLE
genimage: switch to GitHub URL and enable upstream check

### DIFF
--- a/recipes-devtools/genimage/genimage.inc
+++ b/recipes-devtools/genimage/genimage.inc
@@ -7,10 +7,13 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS = "confuse"
 
-SRC_URI = "https://github.com/pengutronix/genimage/releases/download/v${PV}/genimage-${PV}.tar.xz"
+SRC_URI = "${GITHUB_BASE_URI}/download/v${PV}/genimage-${PV}.tar.xz"
 
 EXTRA_OECONF = "--enable-largefile"
 
-inherit pkgconfig autotools gettext
+inherit pkgconfig autotools gettext github-releases
+
+GITHUB_BASE_URI = "https://github.com/pengutronix/genimage/releases"
+UPSTREAM_CHECK_REGEX = "releases/tag/v?(?P<pver>\d+(\.\d+)*)"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/genimage/genimage.inc
+++ b/recipes-devtools/genimage/genimage.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS = "confuse"
 
-SRC_URI = "http://www.pengutronix.de/software/genimage/download/genimage-${PV}.tar.xz"
+SRC_URI = "https://github.com/pengutronix/genimage/releases/download/v${PV}/genimage-${PV}.tar.xz"
 
 EXTRA_OECONF = "--enable-largefile"
 


### PR DESCRIPTION
genimage is hosted and released on [GitHub](https://github.com/pengutronix/genimage) now.