### PR TITLE
genimage: update to v18

### DIFF
--- a/recipes-devtools/genimage/genimage_17.bb
+++ b/recipes-devtools/genimage/genimage_17.bb
@@ -1,3 +1,0 @@
-require genimage.inc
-
-SRC_URI[sha256sum] = "a8756e3567a0d4d82c36b08ccc1e088250b9006d5670c6b2b014185e6ec60671"

--- a/recipes-devtools/genimage/genimage_18.bb
+++ b/recipes-devtools/genimage/genimage_18.bb
@@ -1,0 +1,3 @@
+require genimage.inc
+
+SRC_URI[sha256sum] = "ebc3f886c4d80064dd6c6d5e3c2e98e5a670078264108ce2f89ada8a2e13fedd"


### PR DESCRIPTION
This release includes https://github.com/pengutronix/genimage/pull/243 which changes from genext2fs to e2fsprogs/mke2fs as default for creating ext* images.

This will finally allow us to drop the recipe for genext2fs in a next step.