### PR TITLE
Clarify usage of genimage.bbclass

### DIFF
--- a/classes-recipe/genimage.bbclass
+++ b/classes-recipe/genimage.bbclass
@@ -82,6 +82,11 @@ PACKAGES = ""
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+python () {
+    if bb.data.inherits_class('image', d):
+        bb.fatal("genimage.bbclass is not designed to be inherited by a rootfs image recipe!")
+}
+
 S = "${WORKDIR}/sources"
 UNPACKDIR = "${S}"
 

--- a/classes-recipe/genimage.bbclass
+++ b/classes-recipe/genimage.bbclass
@@ -1,10 +1,10 @@
 # genimage.bbclass
 #
-# Class to generate disk images using the `genimage` tool.
+# Class to generate file system and disk images using the `genimage` tool.
 #
-# In order to build an image, your recipe must inherit the genimage class and
-# have a valid genimage configuration file in SRC_URI, named `genimage.config`
-# by default.
+# In order to build images with this class, you need to create a dedicated disk
+# image recipe! This must inherit the genimage class and have a valid genimage
+# configuration file in SRC_URI (named `genimage.config` by default):
 #
 #   inherit genimage
 #


### PR DESCRIPTION
* Note that a separate recipe is required for `genimage.bbclass`
* Add check if `genimage.bclass` is inherited in a rootfs image recipe

Related to #152 