### PR TITLE
kirkstone-backport: classes: genimage: generalize image symlink creation

### DIFF
--- a/classes/genimage.bbclass
+++ b/classes/genimage.bbclass
@@ -141,13 +141,13 @@ addtask genimage after do_configure before do_build
 do_deploy () {
     install ${B}/* ${DEPLOYDIR}/
 
-    if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_FULLNAME} ]; then
-        ln -sf ${GENIMAGE_IMAGE_FULLNAME} ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_FULLNAME}
-    fi
-    if [ -e ${DEPLOYDIR}/${GENIMAGE_IMAGE_FULLNAME}.bmap ] ; then
-        ln -sf ${GENIMAGE_IMAGE_FULLNAME}.bmap ${DEPLOYDIR}/${GENIMAGE_IMAGE_LINK_FULLNAME}.bmap
-    fi
-
+    for img in ${B}/*; do
+        img=$(basename "${img}")
+        case "$img" in *"${GENIMAGE_IMAGE_FULLNAME}"*)
+            ln -sf ${img} \
+                ${DEPLOYDIR}/$(echo "${img}" | sed "s/${GENIMAGE_IMAGE_FULLNAME}/${GENIMAGE_IMAGE_LINK_FULLNAME}/")
+        esac
+    done
 }
 
 addtask deploy after do_genimage before do_build


### PR DESCRIPTION
A genimage config may generate multiple images, either because multiple image { } clauses are specified or because an exec-post generated further images (e.g. image { exec-post = "gzip -k $IMAGEOUTFILE" })

We already deploy these extra images, but currently symlinks are only created for the plain image and for the bmap file. Make this more generic, so fixed symlinks are created at least for all images using @IMAGE@ as part of their filename.

Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
[ahmad: backport from 518d3c602ab524b9b6ea74152e7e563fb9804758]

---

I need this, because the BSP I work on has a sparse image with a name that keeps changing and I want a fixed symlink to point at it.