### PR TITLE
scarthgap: .github/workflows/build: include release in workflow name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: build (scarthgap)
 
 on:
   push: {}
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: meta-ptx Build
+    name: build
     # run on self-hosted runner for the main repo or if vars.BUILD_RUNS_ON is set
     runs-on: >-
       ${{


### PR DESCRIPTION
This makes the release name appear in the GitHub action badge, making it easier to distinguish the different build in the README.