### PR TITLE
.github/workflows/schedule-builds: Run scheduled jobs via workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
   pull_request: {}
   # allow rebuilding without a push
   workflow_dispatch: {}
-  # pre-build sstate regularly
-  schedule: 
-    - cron: '30 1 * * *'
 
 jobs:
   build:

--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -1,0 +1,31 @@
+name: Schedule Builds
+
+on:
+  # allow rebuilding manually
+  workflow_dispatch:
+  # pre-build sstate regularly
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  build:
+    name: Schedule Builds
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.SCHEDULE_BUILDS }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Trigger master build
+        run: gh workflow run build --ref master
+
+      - name: Trigger styhead build
+        run: gh workflow run build --ref styhead
+
+      - name: Trigger scarthgap build
+        run: gh workflow run build --ref scarthgap
+
+      - name: Trigger kirkstone build
+        run: gh workflow run build --ref kirkstone

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![meta-ptx CI](https://github.com/pengutronix/meta-ptx/workflows/meta-ptx%20CI/badge.svg)](https://github.com/pengutronix/meta-ptx/actions?query=workflow%3A%22meta-ptx+CI%22)
+| master | styhead | scarthgap | kirkstone |
+| ------ | ------- | --------- | --------- |
+| [![build (master)][gh_badge_master]][gh_action_master] | [![build (styhead)][gh_badge_styhead]][gh_action_styhead] | [![build (scarthgap)][gh_badge_scarthgap]][gh_action_scarthgap] | [![build (kirkstone)][gh_badge_kirkstone]][gh_action_kirkstone] |
 
 The meta-ptx layer provides support for classes and recipes that are meant to
 be public but did not make it into any other common layer, yet.
@@ -41,5 +43,14 @@ Maintainer: Enrico Jörns <yocto@pengutronix.de>
 
 Adding the ptx layer to your build
 ==================================
-
 Run ``bitbake-layers add-layer meta-ptx``.
+
+[gh_action_master]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Amaster++
+[gh_action_styhead]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Astyhead++
+[gh_action_scarthgap]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Ascarthgap++
+[gh_action_kirkstone]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Akirkstone++
+
+[gh_badge_master]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=master&event=workflow_dispatch
+[gh_badge_styhead]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=styhead&event=workflow_dispatch
+[gh_badge_scarthgap]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=scarthgap&event=workflow_dispatch
+[gh_badge_kirkstone]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=kirkstone&event=workflow_dispatch


### PR DESCRIPTION
We currently only test the master branch on a regular schedule and not the different release branches (like e.g. scarthgap or styhead).

Also testing these other branches is complicated by the following detail in the GitHub action [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule):

> Scheduled workflows will only run on the default branch

This means we need some sort of workaround to run scheduled jobs on different branches. This commit adds a scheduled job on the master branch to trigger jobs on other branches via the `workflow_dispatch` event.

Build the master branch as well as all current release branches.

This change is based on similar PRs in meta-rauc and meta-labgrid:

- https://github.com/rauc/meta-rauc/pull/357
- https://github.com/labgrid-project/meta-labgrid/pull/57

TODO before merging:

- [x] Merge self-hosted runner and `workflow_dispatch` support for kirkstone https://github.com/pengutronix/meta-ptx/pull/163
- [x] Set the `SCHEDULE_BUILDS` GitHub action variable to a true-ish value.