### PR TITLE
CI: run periodic builds for the walnascar branch 

### DIFF
--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Trigger master build
         run: gh workflow run build --ref master
 
+      - name: Trigger walnascar build
+        run: gh workflow run build --ref walnascar
+
       - name: Trigger styhead build
         run: gh workflow run build --ref styhead
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-| master | styhead | scarthgap | kirkstone |
-| ------ | ------- | --------- | --------- |
-| [![build (master)][gh_badge_master]][gh_action_master] | [![build (styhead)][gh_badge_styhead]][gh_action_styhead] | [![build (scarthgap)][gh_badge_scarthgap]][gh_action_scarthgap] | [![build (kirkstone)][gh_badge_kirkstone]][gh_action_kirkstone] |
+| master | walnascar |styhead | scarthgap | kirkstone |
+| ------ | --------- | ------- | --------- | --------- |
+| [![build (master)][gh_badge_master]][gh_action_master] | [![build (walnascar)][gh_badge_walnascar]][gh_action_walnascar] | [![build (styhead)][gh_badge_styhead]][gh_action_styhead] | [![build (scarthgap)][gh_badge_scarthgap]][gh_action_scarthgap] | [![build (kirkstone)][gh_badge_kirkstone]][gh_action_kirkstone] |
 
 The meta-ptx layer provides support for classes and recipes that are meant to
 be public but did not make it into any other common layer, yet.
@@ -45,11 +45,13 @@ Adding the ptx layer to your build
 Run ``bitbake-layers add-layer meta-ptx``.
 
 [gh_action_master]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Amaster++
+[gh_action_walnascar]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Awalnascar++
 [gh_action_styhead]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Astyhead++
 [gh_action_scarthgap]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Ascarthgap++
 [gh_action_kirkstone]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Akirkstone++
 
 [gh_badge_master]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=master&event=workflow_dispatch
+[gh_badge_walnascar]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=walnascar&event=workflow_dispatch
 [gh_badge_styhead]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=styhead&event=workflow_dispatch
 [gh_badge_scarthgap]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=scarthgap&event=workflow_dispatch
 [gh_badge_kirkstone]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=kirkstone&event=workflow_dispatch


### PR DESCRIPTION
Support for the Yocto `walnascar` release has recently been added to `meta-rauc`.

Also run periodic builds for the release and display their status in the `README.md`.