### PR TITLE
Adapt S / UNPACKDIR handling and add 'whinlatter' to 'LAYERSERIES_COMPAT'

### DIFF
--- a/classes-recipe/genimage.bbclass
+++ b/classes-recipe/genimage.bbclass
@@ -87,8 +87,7 @@ python () {
         bb.fatal("genimage.bbclass is not designed to be inherited by a rootfs image recipe!")
 }
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 B = "${WORKDIR}/genimage-${PN}"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_ptx = "6"
 
 LAYERDEPENDS_ptx = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_ptx = "walnascar"
+LAYERSERIES_COMPAT_ptx = "walnascar whinlatter"

--- a/recipes-core/ptx-profile/ptx-profile.bb
+++ b/recipes-core/ptx-profile/ptx-profile.bb
@@ -4,8 +4,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "file://00-ptx.sh"
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 do_install () {
 	install -d ${D}${sysconfdir}/profile.d/

--- a/recipes-core/systemd/systemd-rc-once.bb
+++ b/recipes-core/systemd/systemd-rc-once.bb
@@ -9,8 +9,7 @@ SRC_URI = "\
   file://systemd-rc-once \
   "
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 inherit allarch systemd
 

--- a/recipes-graphics/platsch/platsch_2024.08.0.bb
+++ b/recipes-graphics/platsch/platsch_2024.08.0.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1a4c8b8d288b4fc32c3c4830d7a5e169"
 
 SRC_URI = "git://github.com/pengutronix/platsch.git;protocol=https;branch=main"
 SRCREV = "157afbc883c6a56d89e78032f230feb8f46ab779"
-S = "${WORKDIR}/git"
 
 DEPENDS = "libdrm"
 


### PR DESCRIPTION
* remove `S = "${WORKDIR}/git"`
*  set `S` from `UNPACKDIR` in recipes that use only local files