### PR TITLE
Replace walnasacar by whinlatter in CI builds and badges.

### DIFF
--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Trigger master build
         run: gh workflow run build --ref master
 
-      - name: Trigger walnascar build
-        run: gh workflow run build --ref walnascar
+      - name: Trigger whinlatter build
+        run: gh workflow run build --ref whinlatter
 
       - name: Trigger scarthgap build
         run: gh workflow run build --ref scarthgap

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-| master | walnascar | scarthgap | kirkstone |
+| master | whinlatter | scarthgap | kirkstone |
 | ------ | --------- | --------- | --------- |
-| [![build (master)][gh_badge_master]][gh_action_master] | [![build (walnascar)][gh_badge_walnascar]][gh_action_walnascar] | [![build (scarthgap)][gh_badge_scarthgap]][gh_action_scarthgap] | [![build (kirkstone)][gh_badge_kirkstone]][gh_action_kirkstone] |
+| [![build (master)][gh_badge_master]][gh_action_master] | [![build (whinlatter)][gh_badge_whinlatter]][gh_action_whinlatter] | [![build (scarthgap)][gh_badge_scarthgap]][gh_action_scarthgap] | [![build (kirkstone)][gh_badge_kirkstone]][gh_action_kirkstone] |
 
 The meta-ptx layer provides support for classes and recipes that are meant to
 be public but did not make it into any other common layer, yet.
@@ -45,11 +45,11 @@ Adding the ptx layer to your build
 Run ``bitbake-layers add-layer meta-ptx``.
 
 [gh_action_master]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Amaster++
-[gh_action_walnascar]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Awalnascar++
+[gh_action_whinlatter]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Awhinlatter++
 [gh_action_scarthgap]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Ascarthgap++
 [gh_action_kirkstone]: https://github.com/pengutronix/meta-ptx/actions?query=event%3Aworkflow_dispatch+branch%3Akirkstone++
 
 [gh_badge_master]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=master&event=workflow_dispatch
-[gh_badge_walnascar]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=walnascar&event=workflow_dispatch
+[gh_badge_whinlatter]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=whinlatter&event=workflow_dispatch
 [gh_badge_scarthgap]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=scarthgap&event=workflow_dispatch
 [gh_badge_kirkstone]: https://github.com/pengutronix/meta-ptx/actions/workflows/build.yml/badge.svg?branch=kirkstone&event=workflow_dispatch

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_ptx = "6"
 
 LAYERDEPENDS_ptx = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_ptx = "walnascar whinlatter"
+LAYERSERIES_COMPAT_ptx = "whinlatter"


### PR DESCRIPTION
Walnascar is EOL and we don't ensure compatibility. Thus drop it.