### PR TITLE
.github/workflows/schedule-builds: give job permission to dispatch jobs

### DIFF
--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -12,6 +12,9 @@ jobs:
     name: Schedule Builds
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || vars.SCHEDULE_BUILDS }}
+    permissions:
+      # needed for triggering other workflows
+      actions: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
We have restricted the default permissions for jobs to read only, which means they can no longer dispatch other workflows.

Give this job the permission to dispatch other jobs, so that scheduled builds work again for all branches.